### PR TITLE
Fix the path of SKILL.md in README.md by pointing to correct path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ This repository contains a few skills to get you started. You can also contribut
 
 | Skill Folder            | Description                                                                                                                | Documentation                                          |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
-| `hf_dataset_creator/`   | Prompts, templates, and scripts for creating structured training datasets.                                                 | [SKILL.md](hf_dataset_creator/SKILL.md)                |
-| `hf_model_evaluation/`  | Instructions plus utilities for orchestrating evaluation jobs, generating reports, and mapping metrics.                    | [SKILL.md](hf_model_evaluation/SKILL.md)               |
-| `hf-llm-trainer/`       | Comprehensive training skill with `SKILL.md` guidance, helper scripts (e.g., `train_sft_example.py`, `convert_to_gguf.py`, cost estimators). | [SKILL.md](hf-llm-trainer/SKILL.md)                    |
-| `hf-paper-publisher/`   | Tools for publishing and managing research papers on Hugging Face Hub. Index papers from arXiv, link papers to models/datasets, generate professional research articles from templates, and manage paper authorship. | [SKILL.md](hf-paper-publisher/SKILL.md)                |
+| `hf_dataset_creator/`   | Prompts, templates, and scripts for creating structured training datasets. | [SKILL.md](hf_dataset_creator/skills/hugging-face-dataset-creator/SKILL.md) |
+| `hf_model_evaluation/`  | Instructions plus utilities for orchestrating evaluation jobs, generating reports, and mapping metrics. | [SKILL.md](hf_model_evaluation/skills/hugging-face-evaluation-manager/SKILL.md) |
+| `hf-llm-trainer/`       | Comprehensive training skill with `SKILL.md` guidance, helper scripts (e.g., `train_sft_example.py`, `convert_to_gguf.py`, cost estimators). | [SKILL.md](hf-llm-trainer/skills/model-trainer/SKILL.md) |
+| `hf-paper-publisher/`   | Tools for publishing and managing research papers on Hugging Face Hub. Index papers from arXiv, link papers to models/datasets, generate professional research articles from templates, and manage paper authorship. | [SKILL.md](hf-paper-publisher/skills/hugging-face-paper-publisher/SKILL.md) |
 
 ### Using skills in your coding agent
 


### PR DESCRIPTION
The paths to SKILL.md were not pointed correctly.