### PR TITLE
Update plugin installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Hugging Face skills are compatible with Claude Code, Codex, and Gemini CLI. With
 For example:  
 
 ```
-/plugin install hf-llm-trainer@huggingface-skills
+/plugin install model-trainer@huggingface-skills
 ```
 
 ### Codex


### PR DESCRIPTION
Make README compliant with the new syntax. 

Also worth noting the blogpost I came from still has the old syntax `hf-llm-trainer`. 
https://huggingface.co/blog/hf-skills-training