### PR TITLE
add `hf models`, `hf datasets` and `hf spaces` commands to hf-cli skill

### DIFF
--- a/skills/hugging-face-cli/SKILL.md
+++ b/skills/hugging-face-cli/SKILL.md
@@ -20,6 +20,12 @@ The `hf` CLI provides direct terminal access to the Hugging Face Hub for downloa
 | Delete files | `hf repo-files delete <repo_id> <files>` |
 | List cache | `hf cache ls` |
 | Remove from cache | `hf cache rm <repo_or_revision>` |
+| List models | `hf models ls` |
+| Get model info | `hf models info <model_id>` |
+| List datasets | `hf datasets ls` |
+| Get dataset info | `hf datasets info <dataset_id>` |
+| List spaces | `hf spaces ls` |
+| Get space info | `hf spaces info <space_id>` |
 | List endpoints | `hf endpoints ls` |
 | Run GPU job | `hf jobs run --flavor a10g-small <image> <cmd>` |
 | Environment info | `hf env` |
@@ -87,6 +93,25 @@ hf cache rm model/gpt2           # Remove cached repo
 hf cache rm <revision_hash>      # Remove cached revision
 hf cache prune                   # Remove detached revisions
 hf cache verify gpt2             # Verify checksums from cache
+```
+
+### Browse Hub
+```bash
+# Models
+hf models ls                                        # List top trending models
+hf models ls --search "MiniMax" --author MiniMaxAI  # Search models
+hf models ls --filter "text-generation" --limit 20  # Filter by task
+hf models info MiniMaxAI/MiniMax-M2.1               # Get model info
+
+# Datasets
+hf datasets ls                                      # List top trending datasets
+hf datasets ls --search "finepdfs" --sort downloads # Search datasets
+hf datasets info HuggingFaceFW/finepdfs             # Get dataset info
+
+# Spaces
+hf spaces ls                                        # List top trending spaces
+hf spaces ls --filter "3d" --limit 10               # Filter by 3D modeling spaces
+hf spaces info enzostvs/deepsite                    # Get space info
 ```
 
 ### Jobs (Cloud Compute)

--- a/skills/hugging-face-cli/references/commands.md
+++ b/skills/hugging-face-cli/references/commands.md
@@ -9,6 +9,9 @@ Complete reference for all `hf` CLI commands and options.
 - [Repository Management](#repository-management)
 - [Repository Files](#repository-files)
 - [Cache Management](#cache-management)
+- [Datasets](#datasets)
+- [Models](#models)
+- [Spaces](#spaces)
 - [Jobs](#jobs)
 - [Inference Endpoints](#inference-endpoints)
 - [Environment](#environment)
@@ -490,6 +493,152 @@ hf cache verify deepseek-ai/DeepSeek-OCR --local-dir /path/to/repo
 | `--token` | Authentication token |
 
 **Note:** Use either `--cache-dir` or `--local-dir`, not both.
+
+---
+
+## Datasets
+
+Interact with datasets on the Hub.
+
+### hf datasets ls
+List datasets on the Hub.
+
+```bash
+hf datasets ls                                      # List top trending datasets
+hf datasets ls --limit 20                           # List more results
+hf datasets ls --search "finepdfs"                  # Search by name
+hf datasets ls --author HuggingFaceFW               # Filter by author/org
+hf datasets ls --filter "task_categories:text-generation"  # Filter by tags
+hf datasets ls --sort downloads                     # Sort by downloads
+hf datasets ls --expand downloads,likes,tags        # Include extra fields
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--search` | Search query |
+| `--author` | Filter by author or organization |
+| `--filter` | Filter by tags (can be used multiple times) |
+| `--sort` | `created_at`, `downloads`, `last_modified`, `likes`, `trending_score` |
+| `--limit` | Number of results (default: 10) |
+| `--expand` | Comma-separated properties to include |
+| `--token` | Authentication token |
+
+**Expandable properties:** `author`, `cardData`, `citation`, `createdAt`, `description`, `disabled`, `downloads`, `downloadsAllTime`, `gated`, `lastModified`, `likes`, `paperswithcode_id`, `private`, `resourceGroup`, `sha`, `siblings`, `tags`, `trendingScore`, `usedStorage`
+
+### hf datasets info
+Get info about a specific dataset on the Hub.
+
+```bash
+hf datasets info HuggingFaceFW/finepdfs
+hf datasets info HuggingFaceFW/finepdfs --revision main
+hf datasets info HuggingFaceFW/finepdfs --expand downloads,likes,tags
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--revision` | Branch, tag, or commit hash |
+| `--expand` | Comma-separated properties to include |
+| `--token` | Authentication token |
+
+---
+
+## Models
+
+Interact with models on the Hub.
+
+### hf models ls
+List models on the Hub.
+
+```bash
+hf models ls                                        # List top trending models
+hf models ls --limit 20                             # List more results
+hf models ls --search "MiniMax"                     # Search by name
+hf models ls --author MiniMaxAI                     # Filter by author/org
+hf models ls --filter "text-generation"             # Filter by tags
+hf models ls --sort downloads                       # Sort by downloads
+hf models ls --expand downloads,likes,tags          # Include extra fields
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--search` | Search query |
+| `--author` | Filter by author or organization |
+| `--filter` | Filter by tags (can be used multiple times) |
+| `--sort` | `created_at`, `downloads`, `last_modified`, `likes`, `trending_score` |
+| `--limit` | Number of results (default: 10) |
+| `--expand` | Comma-separated properties to include |
+| `--token` | Authentication token |
+
+**Expandable properties:** `author`, `baseModels`, `cardData`, `childrenModelCount`, `config`, `createdAt`, `disabled`, `downloads`, `downloadsAllTime`, `gated`, `gguf`, `inference`, `inferenceProviderMapping`, `lastModified`, `library_name`, `likes`, `mask_token`, `model-index`, `pipeline_tag`, `private`, `resourceGroup`, `safetensors`, `sha`, `siblings`, `spaces`, `tags`, `transformersInfo`, `trendingScore`, `usedStorage`, `widgetData`
+
+### hf models info
+Get info about a specific model on the Hub.
+
+```bash
+hf models info MiniMaxAI/MiniMax-M2.1
+hf models info MiniMaxAI/MiniMax-M2.1 --revision main
+hf models info MiniMaxAI/MiniMax-M2.1 --expand downloads,likes,tags,pipeline_tag
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--revision` | Branch, tag, or commit hash |
+| `--expand` | Comma-separated properties to include |
+| `--token` | Authentication token |
+
+---
+
+## Spaces
+
+Interact with spaces on the Hub.
+
+### hf spaces ls
+List spaces on the Hub.
+
+```bash
+hf spaces ls                                        # List top trending spaces
+hf spaces ls --limit 20                             # List more results
+hf spaces ls --search "TRELLIS.2"                    # Search by name
+hf spaces ls --author microsoft                      # Filter by author/org
+hf spaces ls --filter "3d"                          # Filter by 3D modeling spaces
+hf spaces ls --sort likes                           # Sort by likes
+hf spaces ls --expand likes,tags,sdk                # Include extra fields
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--search` | Search query |
+| `--author` | Filter by author or organization |
+| `--filter` | Filter by tags (can be used multiple times) |
+| `--sort` | `created_at`, `last_modified`, `likes`, `trending_score` |
+| `--limit` | Number of results (default: 10) |
+| `--expand` | Comma-separated properties to include |
+| `--token` | Authentication token |
+
+**Note:** `--sort downloads` is not valid for spaces.
+
+**Expandable properties:** `author`, `cardData`, `createdAt`, `datasets`, `disabled`, `lastModified`, `likes`, `models`, `private`, `resourceGroup`, `runtime`, `sdk`, `sha`, `siblings`, `subdomain`, `tags`, `trendingScore`, `usedStorage`
+
+### hf spaces info
+Get info about a specific space on the Hub.
+
+```bash
+hf spaces info enzostvs/deepsite
+hf spaces info enzostvs/deepsite --revision main
+hf spaces info enzostvs/deepsite --expand likes,tags,sdk,runtime
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--revision` | Branch, tag, or commit hash |
+| `--expand` | Comma-separated properties to include |
+| `--token` | Authentication token |
 
 ---
 

--- a/skills/hugging-face-cli/references/examples.md
+++ b/skills/hugging-face-cli/references/examples.md
@@ -3,12 +3,65 @@
 Practical examples for common Hugging Face Hub tasks.
 
 ## Table of Contents
+- [Browse Hub](#browse-hub)
 - [Model Workflows](#model-workflows)
 - [Dataset Workflows](#dataset-workflows)
 - [Space Workflows](#space-workflows)
 - [Inference Endpoints](#inference-endpoints)
 - [Cache Management](#cache-management)
 - [Automation Patterns](#automation-patterns)
+
+---
+
+## Browse Hub
+
+### Discover Models
+
+```bash
+# Find popular text generation models
+hf models ls --filter "text-generation" --sort downloads --limit 10
+
+# Search for specific model architecture
+hf models ls --search "MiniMax" --author MiniMaxAI
+
+# Find models with expanded info
+hf models ls --search "MiniMax" --expand downloads,likes,pipeline_tag
+
+# Get detailed info about a model
+hf models info MiniMaxAI/MiniMax-M2.1
+hf models info MiniMaxAI/MiniMax-M2.1 --expand downloads,likes,tags,config
+```
+
+### Discover Datasets
+
+```bash
+# Find popular datasets
+hf datasets ls --sort downloads --limit 10
+
+# Search for datasets by topic
+hf datasets ls --search "finepdfs" --author HuggingFaceFW
+
+# Get detailed info about a dataset
+hf datasets info HuggingFaceFW/finepdfs
+hf datasets info HuggingFaceFW/finepdfs --expand downloads,likes,description
+```
+
+### Discover Spaces
+
+```bash
+# List top trending spaces
+hf spaces ls --limit 10
+
+# Filter by 3D modeling spaces
+hf spaces ls --filter "3d" --limit 10
+
+# Find spaces by author
+hf spaces ls --author enzostvs --limit 20
+
+# Get detailed info about a space
+hf spaces info enzostvs/deepsite
+hf spaces info enzostvs/deepsite --expand sdk,runtime,likes
+```
 
 ---
 
@@ -309,6 +362,12 @@ hf jobs scheduled ps
 | Create space | `hf repo create <name> --repo-type space --space_sdk gradio` |
 | Tag a release | `hf repo tag create <repo_id> v1.0` |
 | Delete files | `hf repo-files delete <repo_id> <files>` |
+| List models | `hf models ls` |
+| Get model info | `hf models info <model_id>` |
+| List datasets | `hf datasets ls` |
+| Get dataset info | `hf datasets info <dataset_id>` |
+| List spaces | `hf spaces ls` |
+| Get space info | `hf spaces info <space_id>` |
 | Check cache | `hf cache ls` |
 | Clear cache | `hf cache prune` |
 | Run on GPU | `hf jobs run --flavor a10g-small <image> <cmd>` |


### PR DESCRIPTION
This PR updates hf-cli skill to add `hf models`, `hf datasets`, and `hf spaces` commands. see: https://github.com/huggingface/huggingface_hub/releases/tag/v1.3.0

All commands have been tested and verified working.

cc @Wauplin for viz