### PR TITLE
directory location helping hand

### DIFF
--- a/skills/hugging-face-datasets/SKILL.md
+++ b/skills/hugging-face-datasets/SKILL.md
@@ -52,6 +52,12 @@ Supports diverse dataset types through template system:
 
 # Usage Instructions
 
+> **All paths are relative to the directory containing this SKILL.md
+file.**
+> Before running any script, first `cd` to that directory or use the full
+path.
+
+
 The skill includes two Python scripts:
 - `scripts/dataset_manager.py` - Dataset creation and management
 - `scripts/sql_manager.py` - SQL-based dataset querying and transformation

--- a/skills/hugging-face-evaluation/SKILL.md
+++ b/skills/hugging-face-evaluation/SKILL.md
@@ -65,6 +65,12 @@ This prevents spamming model repositories with duplicate evaluation PRs.
 
 ---
 
+> **All paths are relative to the directory containing this SKILL.md
+file.**
+> Before running any script, first `cd` to that directory or use the full
+path.
+
+
 **Use `--help` for the latest workflow guidance.** Works with plain Python or `uv run`:
 ```bash
 uv run scripts/evaluation_manager.py --help

--- a/skills/hugging-face-paper-publisher/SKILL.md
+++ b/skills/hugging-face-paper-publisher/SKILL.md
@@ -59,6 +59,12 @@ The skill includes Python scripts in `scripts/` for paper publishing operations.
 - Set `HF_TOKEN` environment variable with Write-access token
 - Activate virtual environment: `source .venv/bin/activate`
 
+> **All paths are relative to the directory containing this SKILL.md
+file.**
+> Before running any script, first `cd` to that directory or use the full
+path.
+
+
 ### Method 1: Index Paper from arXiv
 
 Add a paper to Hugging Face Paper Pages from arXiv.


### PR DESCRIPTION
some models benefit from a bit of a helping hand finding associated scripts (moonshot k2-instruct/k2-thinking especially). the skills spec is unequivocal about using relative paths; this helps those models find the scripts and reduce their temptation to generate their own.