### PR TITLE
Fix marketplace.json to use skills array format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,44 +9,19 @@
   },
   "plugins": [
     {
-      "name": "hugging-face-model-trainer",
-      "source": "./skills/hugging-face-model-trainer",
-      "description": "Train or fine-tune language models using TRL on Hugging Face Jobs infrastructure. Covers SFT, DPO, GRPO and reward modeling training methods, plus GGUF conversion for local deployment. Includes hardware selection, cost estimation, Trackio monitoring, and Hub persistence."
-    },
-    {
-      "name": "hugging-face-paper-publisher",
-      "source": "./skills/hugging-face-paper-publisher",
-      "description": "Publish and manage research papers on Hugging Face Hub. Supports creating paper pages, linking papers to models/datasets, claiming authorship, and generating professional markdown-based research articles."
-    },
-    {
-      "name": "hugging-face-datasets",
-      "source": "./skills/hugging-face-datasets",
-      "description": "Create and manage datasets on Hugging Face Hub. Supports initializing repos, defining configs/system prompts, streaming row updates, and SQL-based dataset querying/transformation."
-    },
-    {
-      "name": "hugging-face-evaluation",
-      "source": "./skills/hugging-face-evaluation",
-      "description": "Add and manage evaluation results in Hugging Face model cards. Supports extracting eval tables from README content, importing scores from Artificial Analysis API, and running custom evaluations with vLLM/lighteval."
-    },
-    {
-      "name": "hugging-face-tool-builder",
-      "source": "./skills/hugging-face-tool-builder",
-      "description": "Build reusable scripts for Hugging Face API operations. Useful for chaining API calls or automating repeated tasks."
-    },
-    {
-      "name": "hugging-face-cli",
-      "source": "./skills/hugging-face-cli",
-      "description": "Execute Hugging Face Hub operations using the hf CLI. Download models/datasets, upload files, manage repos, and run cloud compute jobs."
-    },
-    {
-      "name": "hugging-face-jobs",
-      "source": "./skills/hugging-face-jobs",
-      "description": "Run compute jobs on Hugging Face infrastructure. Execute Python scripts, manage scheduled jobs, and monitor job status."
-    },
-    {
-      "name": "hugging-face-trackio",
-      "source": "./skills/hugging-face-trackio",
-      "description": "Track and visualize ML training experiments with Trackio. Log metrics via Python API and retrieve them via CLI. Supports real-time dashboards synced to HF Spaces."
+      "name": "huggingface-skills",
+      "description": "Agent Skills for AI/ML tasks including dataset creation, model training, evaluation, and research paper publishing on Hugging Face Hub",
+      "source": "./",
+      "skills": [
+        "./skills/hugging-face-cli",
+        "./skills/hugging-face-datasets",
+        "./skills/hugging-face-evaluation",
+        "./skills/hugging-face-jobs",
+        "./skills/hugging-face-model-trainer",
+        "./skills/hugging-face-paper-publisher",
+        "./skills/hugging-face-tool-builder",
+        "./skills/hugging-face-trackio"
+      ]
     }
   ]
 }


### PR DESCRIPTION
just to do some tests...

## Summary
- Fixes skills not appearing in `/skills` after installing huggingface-skills marketplace
- Changes marketplace.json to match the format expected by Claude Code CLI

## Problem
The marketplace.json was treating individual skill directories as separate plugins:
```json
"plugins": [
  {
    "name": "hugging-face-cli",
    "source": "./skills/hugging-face-cli",
    "description": "..."
  }
]
```

But Claude Code expects plugins to have a `skills` array listing skill paths:
```json
"plugins": [
  {
    "name": "huggingface-skills",
    "source": "./",
    "skills": [
      "./skills/hugging-face-cli",
      "./skills/hugging-face-datasets",
      ...
    ]
  }
]
```

## Solution
Consolidated all skills under a single `huggingface-skills` plugin with a `skills` array, matching the format used by `anthropic-agent-skills` marketplace.

## Test plan
- [ ] Install the marketplace: `/plugin add huggingface/skills`
- [ ] Install the plugin: `/plugin install huggingface-skills@huggingface-skills`
- [ ] Verify skills appear in `/skills` output