### PR TITLE
fix: prevent SQL injection in sql_manager.py (CWE-89)

### DIFF
--- a/skills/hugging-face-datasets/scripts/sql_manager.py
+++ b/skills/hugging-face-datasets/scripts/sql_manager.py
@@ -40,11 +40,15 @@ Usage:
 
 import os
 import json
+import re
 import argparse
 from typing import Optional, List, Dict, Any, Union
 
 import duckdb
 from huggingface_hub import HfApi
+
+# Regex for valid SQL identifiers (column names, view names)
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 # Configuration
@@ -68,11 +72,26 @@ class HFDatasetSQL:
         self.conn = duckdb.connect()
         self._setup_connection()
 
+    @staticmethod
+    def _quote_identifier(name: str) -> str:
+        """Quote a SQL identifier, escaping embedded double-quotes."""
+        return '"' + name.replace('"', '""') + '"'
+
+    @staticmethod
+    def _validate_identifier(name: str) -> None:
+        """Raise ValueError if *name* is not a safe SQL identifier."""
+        if not _IDENTIFIER_RE.match(name):
+            raise ValueError(
+                f"Invalid identifier: {name!r}. "
+                "Identifiers must start with a letter or underscore and contain only "
+                "alphanumeric characters and underscores."
+            )
+
     def _setup_connection(self):
         """Configure DuckDB connection for HF access."""
         # Set HF token if available (for private datasets)
         if self.token:
-            self.conn.execute(f"CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN '{self.token}');")
+            self.conn.execute("CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN $1);", [self.token])
 
     def _build_hf_path(
         self, dataset_id: str, split: str = "*", config: Optional[str] = None, revision: str = "~parquet"
@@ -307,7 +326,8 @@ class HFDatasetSQL:
         """
         hf_path = self._build_hf_path(dataset_id, split=split, config=config)
 
-        sql = f"SELECT DISTINCT {column} FROM '{hf_path}' LIMIT {limit}"
+        quoted_col = self._quote_identifier(column)
+        sql = f"SELECT DISTINCT {quoted_col} FROM '{hf_path}' LIMIT {limit}"
         result = self.conn.execute(sql).fetchall()
 
         return [row[0] for row in result]
@@ -330,12 +350,13 @@ class HFDatasetSQL:
         """
         hf_path = self._build_hf_path(dataset_id, split=split, config=config)
 
+        quoted_col = self._quote_identifier(column)
         sql = f"""
         SELECT 
-            {column},
+            {quoted_col},
             COUNT(*) as count
         FROM '{hf_path}'
-        GROUP BY {column}
+        GROUP BY {quoted_col}
         ORDER BY count DESC
         LIMIT {bins}
         """
@@ -470,6 +491,8 @@ class HFDatasetSQL:
         else:
             processed_sql = f"SELECT * FROM '{hf_path}'"
 
+        if "'" in output_path:
+            raise ValueError(f"Invalid output path: paths must not contain single quotes")
         export_sql = f"COPY ({processed_sql}) TO '{output_path}' (FORMAT PARQUET)"
         self.conn.execute(export_sql)
 
@@ -571,8 +594,10 @@ class HFDatasetSQL:
             split: Dataset split
             config: Optional config
         """
+        self._validate_identifier(name)
         hf_path = self._build_hf_path(dataset_id, split=split, config=config)
-        self.conn.execute(f"CREATE OR REPLACE VIEW {name} AS SELECT * FROM '{hf_path}'")
+        quoted_name = self._quote_identifier(name)
+        self.conn.execute(f"CREATE OR REPLACE VIEW {quoted_name} AS SELECT * FROM '{hf_path}'")
         print(f"✅ Created view '{name}' for {dataset_id}")
 
     def info(self, dataset_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Multiple SQL injection vulnerabilities in `skills/hugging-face-datasets/scripts/sql_manager.py` allow an attacker (or a prompt-injected AI agent executing this skill) to read and write arbitrary local files, drop database objects, or exfiltrate data.

The root cause is **unsanitised string interpolation into SQL queries** combined with DuckDB's `execute()` processing **multiple statements in a single call** — meaning a semicolon in any interpolated value enables stacked-query injection.

## Affected Methods

| Method | Parameter | Vector |
|--------|-----------|--------|
| `_setup_connection()` | `self.token` | f-string into `CREATE SECRET ... TOKEN '...'` — a crafted token value can terminate the string and inject arbitrary SQL |
| `unique_values()` | `column` | f-string into `SELECT DISTINCT {column}` — column name injection |
| `histogram()` | `column` | f-string into `SELECT {column} ... GROUP BY {column}` — column name injection |
| `export_to_parquet()` | `output_path` | f-string into `COPY ... TO '...'` — path breakout / stacked injection |
| `create_view()` | `name` | f-string into `CREATE OR REPLACE VIEW {name}` — view name injection |

## Impact

Since this skill runs inside AI agent environments (Claude Code, Codex, Cursor, Gemini CLI) with the user's full shell permissions, successful injection gives the same access as the user:

- **File read**: `read_csv_auto('/etc/passwd')` or any readable file
- **File write**: `COPY ... TO '/tmp/exfil.csv'` to any writable path
- **Data destruction**: `DROP TABLE`, `DROP VIEW`, etc.
- **Credential access**: Read tokens, SSH keys, or other secrets from disk

In an AI agent context, the attack surface includes prompt injection — a malicious dataset description or column name could trigger these vectors when an agent processes user instructions.

## Proof of Concept

```python
# Token injection — drops a table via stacked query
token = "x'); DROP TABLE IF EXISTS sensitive_data; --"
conn.execute(f"CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN '{token}')")
# Executes: CREATE SECRET ... TOKEN 'x'); DROP TABLE IF EXISTS sensitive_data; --'

# Column injection — writes arbitrary file
column = "1; COPY (SELECT 'pwned') TO '/tmp/pwned.txt'; --"
conn.execute(f"SELECT DISTINCT {column} FROM 'data'")
# Executes: SELECT DISTINCT 1; COPY (SELECT 'pwned') TO '/tmp/pwned.txt'; -- FROM 'data'
```

## Fix

1. **Parameterised query for token** (`$1` placeholder) — DuckDB supports parameterised `CREATE SECRET`:
   ```python
   self.conn.execute("CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN $1);", [self.token])
   ```

2. **Identifier quoting** for column names in `unique_values()` and `histogram()` — double-quote escaping per SQL standard:
   ```python
   @staticmethod
   def _quote_identifier(name: str) -> str:
       return '"' + name.replace('"', '""') + '"'
   ```

3. **Path validation** for `export_to_parquet()` — reject paths containing single quotes to prevent string breakout.

4. **Identifier validation** for `create_view()` — regex allowlist (`^[A-Za-z_][A-Za-z0-9_]*$`) plus quoting.

## Design Note

The `count(where=...)` and `query(sql=...)` methods accept arbitrary SQL by design (that's their intended purpose for agent use). These are not addressed in this PR as sanitising arbitrary SQL would break their core functionality. These methods should be documented as accepting trusted input only.
