### PR TITLE
Add Cursor marketplace manifest for single bundled plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "huggingface-skills",
+  "owner": {
+    "name": "Hugging Face"
+  },
+  "metadata": {
+    "description": "Agent Skills for AI/ML tasks including dataset creation, model training, evaluation, and research paper publishing on Hugging Face Hub",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "huggingface-skills",
+      "source": ".",
+      "skills": "skills",
+      "description": "Agent Skills for AI/ML tasks including dataset creation, model training, evaluation, and research paper publishing on Hugging Face Hub"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `.cursor-plugin/marketplace.json` as a Cursor-specific marketplace manifest
- define exactly one `plugins` entry (`huggingface-skills`) pointing to `source: \".\"` and `skills: \"skills\"`
- reuse the exact existing Hugging Face description text and version metadata without wording changes

## Test plan
- [x] verify file is valid JSON and committed as the only change
- [x] confirm branch diff against `main` contains only `.cursor-plugin/marketplace.json`
- [ ] submit to marketplace and verify it appears as one plugin containing all skills

Made with [Cursor](https://cursor.com)