### PR TITLE
feat: add SECURITY.md for coordinated vulnerability disclosure

### DIFF
--- a/.github/workflows/SECURITY.md
+++ b/.github/workflows/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a Vulnerability
+We take the security of this project seriously. If you discover a security vulnerability within this repository, please **do not open a public issue**. Instead, please report it through one of the following channels:
+
+* **Email:** security@huggingface.co
+* **Hugging Face Hub:** Use the "Report" feature on the repository’s Hub page if applicable.
+
+Please include a detailed description of the vulnerability and, if possible, a Proof of Concept (PoC) to help us reproduce the issue.
+
+## Scope
+The following types of vulnerabilities are of particular interest:
+* **Remote Code Execution (RCE):** Vulnerabilities that allow an agent to execute unauthorized code outside of its intended environment.
+* **Credential Leakage:** Skills that inadvertently expose API keys, tokens, or sensitive environment variables.
+* **Injection Attacks:** Vulnerabilities in skills that handle user input for database queries or shell commands.
+
+## Our Response Process
+1. **Acknowledgment:** We will acknowledge your report within 48 business hours.
+2. **Investigation:** Our team will investigate the issue and determine its impact.
+3. **Fix and Disclosure:** Once a fix is ready, we will coordinate a release and, with your permission, credit you for the discovery.
+
+Thank you for helping keep the Hugging Face ecosystem safe!


### PR DESCRIPTION
This PR adds a SECURITY.md file to establish a clear vulnerability reporting process for agentic skills.

Closes #63 