### PR TITLE
docs: fix Agent Skills grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hugging Face Skills are definitions for AI/ML tasks like dataset creation, model training, and evaluation. They are interoperable with all major coding agent tools like OpenAI Codex, Anthropic's Claude Code, Google DeepMind's Gemini CLI, and Cursor.
 
-The Skills in this repository follow the standardized format [Agent Skill](https://agentskills.io/home) format.
+The skills in this repository follow the standardized [Agent Skills](https://agentskills.io/home) format.
 
 ## How do Skills work?
 


### PR DESCRIPTION
Fix README wording to use Agent Skills naming consistently with the linked specification. Docs-only change.