### PR TITLE
fix(agents): add YAML frontmatter to AGENTS.md

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: huggingface-skills
+description: Hugging Face Agent Skills - specialized instructions and domain-specific knowledge for AI agents
+---
+
 <skills>
 
 You have additional SKILLs documented in directories containing a "SKILL.md" file.


### PR DESCRIPTION
Fixes #79

## Problem
`gemini-cli extensions install` fails with:

```
Invalid agent definition: Missing mandatory YAML frontmatter.
Agent Markdown files MUST start with YAML frontmatter enclosed
in triple-dashes "---" (e.g., ---\nname: my-agent\n---).
```

## Fix
Added required YAML frontmatter:

```yaml
---
name: huggingface-skills
description: Hugging Face Agent Skills - specialized instructions and domain-specific knowledge for AI agents
---
```

## Impact
- ✅ gemini-cli can now successfully install huggingface-skills extension
- ✅ AGENTS.md is now valid agent definition format
- ✅ No functional changes to skills content