### PR TITLE
Sync skill docs with actual huggingface_hub CLI commands

### DIFF
--- a/skills/hf-cli/SKILL.md
+++ b/skills/hf-cli/SKILL.md
@@ -78,7 +78,6 @@ Generated with `huggingface_hub v1.7.1`. Run `hf skills add --force` to regenera
 
 ### `hf endpoints` — Manage Hugging Face Inference Endpoints.
 
-- `hf endpoints catalog` — Interact with the Inference Endpoints catalog.
 - `hf endpoints delete NAME` — Delete an Inference Endpoint permanently.
 - `hf endpoints deploy NAME repo framework accelerator instance_size instance_type region vendor` — Deploy an Inference Endpoint from a Hub repository.
 - `hf endpoints describe NAME` — Get information about an existing endpoint.
@@ -87,6 +86,11 @@ Generated with `huggingface_hub v1.7.1`. Run `hf skills add --force` to regenera
 - `hf endpoints resume NAME` — Resume an Inference Endpoint.
 - `hf endpoints scale-to-zero NAME` — Scale an Inference Endpoint to zero.
 - `hf endpoints update NAME` — Update an existing endpoint.
+
+#### `hf endpoints catalog` — Interact with the Inference Endpoints catalog.
+
+- `hf endpoints catalog deploy` — Deploy an Inference Endpoint from the Model Catalog.
+- `hf endpoints catalog list` — List available Catalog models.
 
 ### `hf extensions` — Manage hf CLI extensions.
 
@@ -104,9 +108,18 @@ Generated with `huggingface_hub v1.7.1`. Run `hf skills add --force` to regenera
 - `hf jobs logs JOB_ID` — Fetch the logs of a Job.
 - `hf jobs ps` — List Jobs.
 - `hf jobs run IMAGE COMMAND` — Run a Job.
-- `hf jobs scheduled` — Create and manage scheduled Jobs on the Hub.
 - `hf jobs stats` — Fetch the resource usage statistics and metrics of Jobs
-- `hf jobs uv` — Run UV scripts (Python with inline dependencies) on HF infrastructure.
+- `hf jobs uv run SCRIPT` — Run a UV script (local file or URL) on HF infrastructure.
+
+#### `hf jobs scheduled` — Create and manage scheduled Jobs on the Hub.
+
+- `hf jobs scheduled run SCHEDULE IMAGE COMMAND` — Schedule a Job.
+- `hf jobs scheduled ps` — List scheduled Jobs.
+- `hf jobs scheduled inspect SCHEDULED_JOB_IDS` — Display detailed information on one or more scheduled Jobs.
+- `hf jobs scheduled delete SCHEDULED_JOB_ID` — Delete a scheduled Job.
+- `hf jobs scheduled suspend SCHEDULED_JOB_ID` — Suspend (pause) a scheduled Job.
+- `hf jobs scheduled resume SCHEDULED_JOB_ID` — Resume (unpause) a scheduled Job.
+- `hf jobs scheduled uv run SCHEDULE SCRIPT` — Schedule a UV script on HF infrastructure.
 
 ### `hf models` — Interact with models on the Hub.
 
@@ -119,14 +132,23 @@ Generated with `huggingface_hub v1.7.1`. Run `hf skills add --force` to regenera
 
 ### `hf repos` — Manage repos on the Hub.
 
-- `hf repos branch` — Manage branches for a repo on the Hub.
 - `hf repos create REPO_ID` — Create a new repo on the Hub.
 - `hf repos delete REPO_ID` — Delete a repo from the Hub. This is an irreversible operation.
 - `hf repos delete-files REPO_ID PATTERNS` — Delete files from a repo on the Hub.
 - `hf repos duplicate FROM_ID` — Duplicate a repo on the Hub (model, dataset, or Space).
 - `hf repos move FROM_ID TO_ID` — Move a repository from a namespace to another namespace.
 - `hf repos settings REPO_ID` — Update the settings of a repository.
-- `hf repos tag` — Manage tags for a repo on the Hub.
+
+#### `hf repos branch` — Manage branches for a repo on the Hub.
+
+- `hf repos branch create REPO_ID BRANCH` — Create a new branch for a repo on the Hub.
+- `hf repos branch delete REPO_ID BRANCH` — Delete a branch from a repo on the Hub.
+
+#### `hf repos tag` — Manage tags for a repo on the Hub.
+
+- `hf repos tag create REPO_ID TAG` — Create a tag for a repo.
+- `hf repos tag list REPO_ID` — List tags for a repo.
+- `hf repos tag delete REPO_ID TAG` — Delete a tag for a repo.
 
 ### `hf skills` — Manage skills for AI assistants.
 

--- a/skills/hugging-face-jobs/SKILL.md
+++ b/skills/hugging-face-jobs/SKILL.md
@@ -1037,6 +1037,8 @@ Add to PEP 723 header:
 | List jobs | `hf_jobs("ps")` | `hf jobs ps` | `list_jobs()` |
 | View logs | `hf_jobs("logs", {...})` | `hf jobs logs <id>` | `fetch_job_logs(job_id)` |
 | Cancel job | `hf_jobs("cancel", {...})` | `hf jobs cancel <id>` | `cancel_job(job_id)` |
-| Schedule UV | `hf_jobs("scheduled uv", {...})` | - | `create_scheduled_uv_job()` |
-| Schedule Docker | `hf_jobs("scheduled run", {...})` | - | `create_scheduled_job()` |
+| Schedule UV | `hf_jobs("scheduled uv", {...})` | `hf jobs scheduled uv run SCHEDULE script.py` | `create_scheduled_uv_job()` |
+| Schedule Docker | `hf_jobs("scheduled run", {...})` | `hf jobs scheduled run SCHEDULE image cmd` | `create_scheduled_job()` |
+| List scheduled | `hf_jobs("scheduled ps")` | `hf jobs scheduled ps` | `list_scheduled_jobs()` |
+| Delete scheduled | `hf_jobs("scheduled delete", {...})` | `hf jobs scheduled delete <id>` | `delete_scheduled_job()` |
 

--- a/skills/hugging-face-tool-builder/SKILL.md
+++ b/skills/hugging-face-tool-builder/SKILL.md
@@ -95,16 +95,26 @@ Options:
 
 Commands:
   auth                 Manage authentication (login, logout, etc.).
+  buckets              Commands to interact with buckets.
   cache                Manage local cache directory.
+  collections          Interact with collections on the Hub.
+  datasets             Interact with datasets on the Hub.
+  discussions          Manage discussions and pull requests on the Hub.
   download             Download files from the Hub.
   endpoints            Manage Hugging Face Inference Endpoints.
   env                  Print information about the environment.
+  extensions           Manage hf CLI extensions.
   jobs                 Run and manage Jobs on the Hub.
-  repo                 Manage repos on the Hub.
-  repo-files           Manage files in a repo on the Hub.
+  models               Interact with models on the Hub.
+  papers               Interact with papers on the Hub.
+  repos                Manage repos on the Hub.
+  skills               Manage skills for AI assistants.
+  spaces               Interact with spaces on the Hub.
+  sync                 Sync files between local directory and a bucket.
   upload               Upload a file or a folder to the Hub.
   upload-large-folder  Upload a large folder to the Hub.
   version              Print information about the hf version.
+  webhooks             Manage webhooks on the Hub.
 ```
 
-The `hf` CLI command has replaced the now deprecated `huggingface_hub` CLI command.
+The `hf` CLI command has replaced the now deprecated `huggingface-cli` command.


### PR DESCRIPTION
## Summary

Cross-referenced all skill files against [`huggingface_hub@b23f3e04`](https://github.com/huggingface/huggingface_hub/commit/b23f3e0407fbc4c06766dee2761af3a9ca3777b7) and found several documentation gaps.

### hf-cli/SKILL.md — Add missing subcommands

- **`hf jobs scheduled`** (run/ps/inspect/delete/suspend/resume/uv run) — these subcommands exist in [`cli/jobs.py` L842–L1055](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/cli/jobs.py#L842-L1055) but were listed as a single unexpanded entry
- **`hf repos branch`** (create/delete) — exist in [`cli/repos.py` L290–L346](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/cli/repos.py#L290-L346) but were listed as a single unexpanded entry
- **`hf repos tag`** (create/list/delete) — exist in [`cli/repos.py` L349–L434](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/cli/repos.py#L349-L434) but were listed as a single unexpanded entry
- **`hf endpoints catalog`** (deploy/list) — exist in [`cli/inference_endpoints.py` L200–L253](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/cli/inference_endpoints.py#L200-L253) but were listed as a single unexpanded entry
- Fixed `hf jobs uv` → `hf jobs uv run SCRIPT` to match actual command signature

### hugging-face-tool-builder/SKILL.md — Update stale `hf --help` output

- Added 12 missing command groups: `buckets`, `collections`, `datasets`, `discussions`, `extensions`, `models`, `papers`, `repos`, `skills`, `spaces`, `sync`, `webhooks` — all registered in [`cli/hf.py` L89–L104](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/cli/hf.py#L89-L104)
- Replaced deprecated `repo` / `repo-files` with current `repos`
- Fixed typo: `huggingface_hub` → `huggingface-cli` in deprecation note

### hugging-face-jobs/SKILL.md — Fix Quick Reference table

- Added CLI equivalents for scheduled job operations (previously showed `-` despite CLI commands existing in [`cli/jobs.py`](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/cli/jobs.py#L842-L1055))
- Added `list scheduled` and `delete scheduled` rows

## Note

Also found that `list_scheduled_jobs` is defined in [`hf_api.py` L11295](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/hf_api.py#L11295) but **not exported** in `__init__.py` (all other scheduled job functions are). This is a bug in `huggingface_hub` itself — will open a separate PR there.

## Test plan

- [ ] Verify `hf-cli/SKILL.md` subcommands match `hf <command> --help` output
- [ ] Verify `hugging-face-tool-builder/SKILL.md` matches `hf --help`
- [ ] Verify `hugging-face-jobs/SKILL.md` quick reference table is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)