### PR TITLE
tool-builder: update stale hf --help output with all current commands

### DIFF
--- a/skills/hugging-face-tool-builder/SKILL.md
+++ b/skills/hugging-face-tool-builder/SKILL.md
@@ -95,16 +95,26 @@ Options:
 
 Commands:
   auth                 Manage authentication (login, logout, etc.).
+  buckets              Commands to interact with buckets.
   cache                Manage local cache directory.
+  collections          Interact with collections on the Hub.
+  datasets             Interact with datasets on the Hub.
+  discussions          Manage discussions and pull requests on the Hub.
   download             Download files from the Hub.
   endpoints            Manage Hugging Face Inference Endpoints.
   env                  Print information about the environment.
+  extensions           Manage hf CLI extensions.
   jobs                 Run and manage Jobs on the Hub.
-  repo                 Manage repos on the Hub.
-  repo-files           Manage files in a repo on the Hub.
+  models               Interact with models on the Hub.
+  papers               Interact with papers on the Hub.
+  repos                Manage repos on the Hub.
+  skills               Manage skills for AI assistants.
+  spaces               Interact with spaces on the Hub.
+  sync                 Sync files between local directory and a bucket.
   upload               Upload a file or a folder to the Hub.
   upload-large-folder  Upload a large folder to the Hub.
   version              Print information about the hf version.
+  webhooks             Manage webhooks on the Hub.
 ```
 
-The `hf` CLI command has replaced the now deprecated `huggingface_hub` CLI command.
+The `hf` CLI command has replaced the now deprecated `huggingface-cli` command.


### PR DESCRIPTION
## Summary

- Add 12 missing command groups to the `hf --help` listing: `buckets`, `collections`, `datasets`, `discussions`, `extensions`, `models`, `papers`, `repos`, `skills`, `spaces`, `sync`, `webhooks`
- Replace deprecated `repo` / `repo-files` with current `repos`
- Fix typo: `huggingface_hub` → `huggingface-cli` in deprecation note

## Source reference ([huggingface_hub@b23f3e04](https://github.com/huggingface/huggingface_hub/commit/b23f3e0407fbc4c06766dee2761af3a9ca3777b7))

All command groups are registered in [`cli/hf.py` L89–L104](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/cli/hf.py#L89-L104):

```python
app.add_typer(auth_cli, name="auth")
app.add_typer(buckets_cli, name="buckets")
app.add_typer(cache_cli, name="cache")
app.add_typer(collections_cli, name="collections")
app.add_typer(datasets_cli, name="datasets")
app.add_typer(discussions_cli, name="discussions")
app.add_typer(jobs_cli, name="jobs")
app.add_typer(models_cli, name="models")
app.add_typer(papers_cli, name="papers")
app.add_typer(repos_cli, name="repos | repo")
app.add_typer(repo_files_cli, name="repo-files", hidden=True)  # deprecated
app.add_typer(skills_cli, name="skills")
app.add_typer(spaces_cli, name="spaces")
app.add_typer(webhooks_cli, name="webhooks")
app.add_typer(ie_cli, name="endpoints")
app.add_typer(extensions_cli, name="extensions | ext")
```

## Test plan

- [ ] Verify listing matches `hf --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)