### PR TITLE
jobs: add scheduled jobs CLI commands to Quick Reference table

### DIFF
--- a/skills/hugging-face-jobs/SKILL.md
+++ b/skills/hugging-face-jobs/SKILL.md
@@ -1037,6 +1037,8 @@ Add to PEP 723 header:
 | List jobs | `hf_jobs("ps")` | `hf jobs ps` | `list_jobs()` |
 | View logs | `hf_jobs("logs", {...})` | `hf jobs logs <id>` | `fetch_job_logs(job_id)` |
 | Cancel job | `hf_jobs("cancel", {...})` | `hf jobs cancel <id>` | `cancel_job(job_id)` |
-| Schedule UV | `hf_jobs("scheduled uv", {...})` | - | `create_scheduled_uv_job()` |
-| Schedule Docker | `hf_jobs("scheduled run", {...})` | - | `create_scheduled_job()` |
+| Schedule UV | `hf_jobs("scheduled uv", {...})` | `hf jobs scheduled uv run SCHEDULE script.py` | `create_scheduled_uv_job()` |
+| Schedule Docker | `hf_jobs("scheduled run", {...})` | `hf jobs scheduled run SCHEDULE image cmd` | `create_scheduled_job()` |
+| List scheduled | `hf_jobs("scheduled ps")` | `hf jobs scheduled ps` | `list_scheduled_jobs()` |
+| Delete scheduled | `hf_jobs("scheduled delete", {...})` | `hf jobs scheduled delete <id>` | `delete_scheduled_job()` |
 


### PR DESCRIPTION
## Summary

- Replace `-` placeholders with actual CLI commands for scheduled job operations
- Add `list scheduled` and `delete scheduled` rows for completeness

The Quick Reference table previously showed `-` for the CLI column on scheduled jobs, but these CLI commands exist.

## Source reference ([huggingface_hub@b23f3e04](https://github.com/huggingface/huggingface_hub/commit/b23f3e0407fbc4c06766dee2761af3a9ca3777b7))

Scheduled job CLI commands are defined in [`cli/jobs.py` L842–L1055](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/cli/jobs.py#L842-L1055):

- `hf jobs scheduled run` (L842)
- `hf jobs scheduled ps` (L889)
- `hf jobs scheduled inspect` (L995)
- `hf jobs scheduled delete` (L1020)
- `hf jobs scheduled suspend` (L1032)
- `hf jobs scheduled resume` (L1044)
- `hf jobs scheduled uv run` (registered via `scheduled_uv_app`)

## Note

`list_scheduled_jobs` is referenced in the Python API column but is not exported in [`huggingface_hub/__init__.py`](https://github.com/huggingface/huggingface_hub/blob/b23f3e04/src/huggingface_hub/__init__.py) (all other scheduled job functions are). This is a separate bug in `huggingface_hub` itself.

## Test plan

- [ ] Verify CLI commands match `hf jobs scheduled --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)