### PR TITLE
fix: add YAML frontmatter to AGENTS.md

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: huggingface-skills
+description: Hugging Face skills for AI agents - access models, datasets, spaces, papers, training, and more from the HF ecosystem.
+---
+
 <skills>
 
 You have additional SKILLs documented in directories containing a "SKILL.md" file.


### PR DESCRIPTION
Fixes #121

Add required YAML frontmatter (name and description fields) to `agents/AGENTS.md` to fix Gemini CLI ExtensionManager loading error: "Invalid agent definition: Missing mandatory YAML frontmatter".

This also addresses the issue described in #79 and proposed in #78 where users who manually patch their local AGENTS.md file have their fixes overwritten on `gemini extensions update`.

### Changes
- Added YAML frontmatter block with `name` and `description` fields at the top of `agents/AGENTS.md`