### PR TITLE
fix: add YAML frontmatter to agents/AGENTS.md

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: huggingface-skills
+description: Hugging Face skills for working with the HF ecosystem — models, datasets, spaces, training, evaluation, and more.
+---
+
 <skills>
 
 You have additional SKILLs documented in directories containing a "SKILL.md" file.


### PR DESCRIPTION
AGENTS.md is missing the YAML frontmatter block that Gemini CLI requires to load the extension properly. Without it, installing the extension throws:

```
Error loading agent from huggingface-skills: Invalid agent definition: Missing mandatory YAML frontmatter
```

and anyone who patches it locally gets the broken version pulled back every time they run `gemini extensions update`.

just adds the frontmatter at the top of the file, nothing else changes.

same fix as #78 which has been sitting open for a while — closes #121 and #79