### PR TITLE
update dataset viewer skill for agent traces + `hf datasets sql` syntax

### DIFF
--- a/skills/huggingface-datasets/SKILL.md
+++ b/skills/huggingface-datasets/SKILL.md
@@ -53,36 +53,7 @@ Search/filter notes:
 - `/filter` requires predicate syntax in `where` and optional sort in `orderby`.
 - Keep filtering and searches read-only and side-effect free.
 
-## Querying Datasets
-
-Use `npx parquetlens` with Hub parquet alias paths for SQL querying.
-
-Parquet alias shape:
-
-```text
-hf://datasets/<namespace>/<repo>@~parquet/<config>/<split>/<shard>.parquet
-```
-
-Derive `<config>`, `<split>`, and `<shard>` from Dataset Viewer `/parquet`:
-
-```bash
-curl -s "https://datasets-server.huggingface.co/parquet?dataset=cfahlgren1/hub-stats" \
-  | jq -r '.parquet_files[] | "hf://datasets/\(.dataset)@~parquet/\(.config)/\(.split)/\(.filename)"'
-```
-
-Run SQL query:
-
-```bash
-npx -y -p parquetlens -p @parquetlens/sql parquetlens \
-  "hf://datasets/<namespace>/<repo>@~parquet/<config>/<split>/<shard>.parquet" \
-  --sql "SELECT * FROM data LIMIT 20"
-```
-
-### SQL export
-
-- CSV: `--sql "COPY (SELECT * FROM data LIMIT 1000) TO 'export.csv' (FORMAT CSV, HEADER, DELIMITER ',')"`
-- JSON: `--sql "COPY (SELECT * FROM data LIMIT 1000) TO 'export.json' (FORMAT JSON)"`
-- Parquet: `--sql "COPY (SELECT * FROM data LIMIT 1000) TO 'export.parquet' (FORMAT PARQUET)"`
+For CLI-based parquet URL discovery or SQL, use the `hf-cli` skill with `hf datasets parquet` and `hf datasets sql`.
 
 ## Creating and Uploading Datasets
 
@@ -119,3 +90,18 @@ npx -y @huggingface/hub upload datasets/<namespace>/<repo> ./local/parquet-folde
 ```
 
 After upload, call `/parquet` to discover `<config>/<split>/<shard>` values for querying with `@~parquet`.
+
+## Agent Traces
+
+The Hub supports raw agent session traces from Claude Code, Codex, and Pi Agent. Upload them to Hugging Face Datasets as original JSONL files and the Hub can auto-detect the trace format, tag the dataset as `Traces`, and enable the trace viewer for browsing sessions, turns, tool calls, and model responses. Common local session directories:
+
+- Claude Code: `~/.claude/projects`
+- Codex: `~/.codex/sessions`
+- Pi: `~/.pi/agent/sessions`
+
+Default to private dataset repos because traces can contain prompts, file paths, tool outputs, secrets, or PII. Preserve the raw `.jsonl` files and nest them by project/cwd instead of uploading every session at the dataset root.
+
+```bash
+hf repos create <namespace>/<repo> --type dataset --private --exist-ok
+hf upload <namespace>/<repo> ~/.codex/sessions codex/<project-or-cwd> --type dataset
+```


### PR DESCRIPTION
- Replace the parquetlens SQL instructions with the native `hf datasets parquet` and `hf datasets sql` flow.
- Add Agent Traces guidance for Claude Code, Codex, and Pi Agent JSONL uploads.
