### PR TITLE
Sync skills to HF bucket on merge to main

### DIFF
--- a/.github/workflows/sync-skills-to-bucket.yml
+++ b/.github/workflows/sync-skills-to-bucket.yml
@@ -1,0 +1,30 @@
+name: Sync skills to bucket
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - ".claude-plugin/marketplace.json"
+      - ".github/workflows/sync-skills-to-bucket.yml"
+
+concurrency:
+  group: sync-skills-to-bucket
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+
+      - name: Sync skills to bucket
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          uvx hf buckets sync ./skills hf://buckets/huggingface/skills/skills --delete
+          uvx hf buckets cp ./.claude-plugin/marketplace.json hf://buckets/huggingface/skills/marketplace.json


### PR DESCRIPTION
> Context in this private Slack [thread](https://huggingface.slack.com/archives/C08LXQBA0AG/p1777556505603329).

This PR adds a workflow that syncs the contents of `skills/` and `.claude-plugin/marketplace.json` to the [`huggingface/skills` bucket](https://huggingface.co/buckets/huggingface/skills) on every merge to `main`.

`hf skills add` currently fetches skills directly from this repo via the GitHub API, so the rate limit is shared with anything else hitting GitHub from the same machine. mirroring skills to a bucket lets the CLI fetch them from there instead (follow-up PR in `huggingface_hub`), avoiding the GH rate limit entirely. The repo stays the source of truth for versioning, PRs, and other tools, the bucket is just a distribution layer for the latest version on `main`.