### PR TITLE
Recommend hf-cli as the first Skill to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Hugging Face Skills are definitions for AI/ML tasks like dataset creation, model
 
 The skills in this repository follow the standardized [Agent Skills](https://agentskills.io/home) format.
 
+> [!NOTE]
+> **Just want to give your agent access to the Hugging Face Hub?** Start with [`hf-cli`](https://huggingface.co/docs/hub/agents-cli). It's the recommended first Skill to install: it teaches your agent every `hf` command (search models, manage datasets and buckets, launch Spaces, run jobs) and is generated from your locally installed CLI so it stays current.
+
 ## How do Skills work?
 
 In practice, skills are self-contained folders that package instructions, scripts, and resources together for an AI agent to use on a specific use case. Each folder includes a `SKILL.md` file with YAML frontmatter (name and description) followed by the guidance your coding agent follows while the skill is active. 


### PR DESCRIPTION
encouraging to install the most important Skill:

<img width="4236" height="1484" alt="image" src="https://github.com/user-attachments/assets/4b8bdfd7-18e1-44f8-a3e9-092d02c22807" />

## Summary
- Add a `[!NOTE]` callout at the top of the README pointing users who just want to give their agent access to the Hugging Face Hub to install `hf-cli` first.
- Link directly to the new [Hugging Face CLI for AI Agents](https://huggingface.co/docs/hub/agents-cli) docs page on hub-docs.

## Test plan
- [ ] Render preview on GitHub: confirm the `[!NOTE]` block displays correctly and the `hf-cli` link resolves.