### PR TITLE
Add deploy-mcp-server-on-hf skill

### DIFF
--- a/skills/deploy-mcp-server-on-hf/SKILL.md
+++ b/skills/deploy-mcp-server-on-hf/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: deploy-mcp-server-on-hf
+description: >-
+  Deploy/host an MCP server on Hugging Face Spaces. Use when the user wants to
+  publish an MCP server on HF, turn a Gradio app or Python tools into an MCP
+  server, package an existing (Node/Python/etc.) HTTP/SSE MCP server as a Space,
+  or choose between the Gradio-native and Docker paths. Covers the non-obvious
+  parts (transport, app_port routing, private-Space auth, secrets, bucket
+  mounts, cold starts) and points to the official docs instead of duplicating
+  them.
+---
+
+# Deploy an MCP server on Hugging Face
+
+Hugging Face **Spaces** are the way to host a long-running MCP server (Jobs are
+ephemeral; Inference Endpoints are model-oriented). There are two paths — pick
+by what the server *is*.
+
+## Decision
+
+| Situation | Path |
+|---|---|
+| Python functions/tools you want exposed as MCP tools | **A — Gradio Space (native MCP)** |
+| An existing MCP server, or non-Python (Node, Go…), or you need full control of the endpoint/transport | **B — Docker Space** |
+| You just want an existing **Gradio Space** as a tool (not to host a server) | Don't deploy anything — proxy it via `huggingface.co/mcp` / `hf-mcp-server` (see Pointers) |
+
+Hard rule for both: a Space is reached over HTTP, so the server **must** speak
+**Streamable HTTP** (preferred) or **SSE** (legacy). **stdio does not work
+remotely.**
+
+## Path A — Gradio Space (native MCP)
+
+Lowest effort for Python. Gradio turns decorated functions (their type hints +
+**docstrings** become the MCP tool schema) into MCP tools when you enable the
+MCP server.
+
+1. `requirements.txt` includes `gradio[mcp]`.
+2. Enable it: `demo.launch(mcp_server=True)` (or env `GRADIO_MCP_SERVER=true`).
+3. Create a **Gradio SDK** Space and push the code.
+
+The MCP endpoint is published by Gradio (path + SSE/Streamable-HTTP details are
+in the guide). **Do not re-derive these steps — follow the canonical guide:**
+- Gradio guide: https://www.gradio.app/guides/building-mcp-server-with-gradio
+- Course walkthrough: https://huggingface.co/learn/mcp-course/en/unit2/gradio-server
+- Spaces-as-MCP overview: https://huggingface.co/docs/hub/en/spaces-mcp-servers
+
+## Path B — Docker Space (any MCP server)
+
+For an existing/other-language MCP server. This generic path is **not** written
+up as an MCP guide, so the concrete recipe + gotchas live in
+[references/docker-space-mcp.md](references/docker-space-mcp.md). Base Spaces
+docs: https://huggingface.co/docs/hub/spaces-sdks-docker and the config
+reference: https://huggingface.co/docs/hub/spaces-config-reference
+
+The parts that bite (covered in the reference):
+- **`app_port`** in the Space `README.md` metadata MUST match the port your
+  server listens on (HF routes external traffic there; default is 7860). This
+  is the #1 reason a deploy "builds but won't connect".
+- Listen on `0.0.0.0`, not localhost.
+- **Private vs public**: a private Space requires clients to send
+  `Authorization: Bearer <hf_token>`; or use "Sign in with HF" OAuth.
+- **Secrets** (tokens) vs **variables** (config) in Space settings — never bake
+  tokens into the image.
+- **Persistent data / shared catalogs** via volume/bucket mounts
+  (`hf spaces volumes set … -v hf://buckets/<ns>/<bucket>:/mnt/…:ro`).
+- **Cold starts**: free CPU Spaces sleep after inactivity — set `sleep_time` or
+  use paid hardware; the first request after sleep is slow.
+- Design **stateless** (Spaces restart/scale).
+
+## Verify it
+
+1. URL pattern: `https://<user>-<space>.hf.space/<mcp-endpoint>`.
+2. Quick check — do an MCP `initialize` POST (curl/Python) and confirm
+   `serverInfo` + the capabilities you expect; for a private Space include the
+   `Authorization: Bearer` header. Or use the **MCP Inspector**, or point a real
+   client (Claude Desktop config, fast-agent, etc.).
+3. Client caveat worth knowing: some clients surface **tools** but not
+   **resources/skills** (e.g. `fast-agent go` consumes tools only) — test with a
+   client that exercises the surface you care about.
+
+## Pointers (don't duplicate these — link/read them)
+
+- Spaces as MCP servers: https://huggingface.co/docs/hub/en/spaces-mcp-servers
+- HF MCP server / proxying Spaces as tools: https://huggingface.co/docs/hub/hf-mcp-server · https://huggingface.co/docs/hub/en/agents-mcp
+- Gradio MCP: https://www.gradio.app/guides/building-mcp-server-with-gradio · https://huggingface.co/blog/gradio-mcp · https://huggingface.co/blog/gradio-mcp-servers
+- MCP Course: https://huggingface.co/learn/mcp-course
+- Docker Spaces: https://huggingface.co/docs/hub/spaces-sdks-docker · config: https://huggingface.co/docs/hub/spaces-config-reference
+- MCP spec (transports): https://modelcontextprotocol.io

--- a/skills/deploy-mcp-server-on-hf/references/docker-space-mcp.md
+++ b/skills/deploy-mcp-server-on-hf/references/docker-space-mcp.md
@@ -1,0 +1,97 @@
+# Packaging any MCP server as a Docker Space
+
+Concrete recipe for hosting an existing/non-Gradio MCP server (Node, Python, Go,
+…) on a Hugging Face **Docker** Space. The HF Spaces docs cover Docker generally
+(https://huggingface.co/docs/hub/spaces-sdks-docker) and the metadata fields
+(https://huggingface.co/docs/hub/spaces-config-reference); this file fills the
+MCP-specific gaps.
+
+## 1. The server must serve HTTP
+
+Expose a **Streamable HTTP** (preferred) or **SSE** MCP endpoint and listen on
+`0.0.0.0:<port>`. stdio-only servers cannot be reached remotely — wrap them in
+an HTTP transport first.
+
+## 2. `README.md` metadata (this is the Space config)
+
+The Space's `README.md` MUST start with a YAML block. `app_port` is the critical
+one — HF routes external HTTPS to that container port (default 7860 if unset).
+If it doesn't match your server's listen port, the build succeeds but nothing
+connects.
+
+```yaml
+---
+title: My MCP Server
+emoji: 🛠️
+colorFrom: blue
+colorTo: green
+sdk: docker
+app_port: 3000        # MUST equal the port your server listens on
+pinned: false
+short_description: <= 60 chars
+---
+```
+
+## 3. Dockerfile (shape)
+
+```dockerfile
+FROM node:22-alpine          # or python:3.12-slim, etc.
+WORKDIR /app
+COPY . .
+RUN <install deps> && <build>
+ENV PORT=3000                # whatever your server reads; must match app_port
+EXPOSE 3000
+CMD ["<start your HTTP MCP server, bound to 0.0.0.0:$PORT>"]
+```
+
+Gotchas:
+- Bind `0.0.0.0`, not `127.0.0.1`.
+- Confirm which env var your server actually reads for the port (it is not always
+  `PORT`) — set that one, and make it equal `app_port`.
+- Mind your build tool's non-interactive/CI quirks (lockfile-frozen installs,
+  ignored build scripts, etc.) — a Space build runs headless.
+
+## 4. Create + deploy
+
+```bash
+hf repos create <user>/<space> --type space --space-sdk docker [--private]
+# push code: either `git push` to the Space remote, or:
+hf upload <user>/<space> . . --repo-type space    # or huggingface_hub.upload_folder
+```
+
+## 5. Config that doesn't go in the image
+
+- **Secrets** (tokens, keys) and **variables** (non-secret config): set in the
+  Space *Settings* (or `huggingface_hub.add_space_secret` / `add_space_variable`).
+  Never bake secrets into the Dockerfile/image.
+- **Persistent data or a shared catalog** (e.g. a skills bucket): mount a volume
+  ```bash
+  hf spaces volumes set <user>/<space> -v hf://buckets/<ns>/<bucket>:/mnt/data:ro
+  ```
+  then point your server at the mount path via a variable.
+
+## 6. Access + auth
+
+- URL: `https://<user>-<space>.hf.space/<mcp-endpoint>`.
+- **Public** Space → open endpoint (anyone with the URL). **Private** Space →
+  clients must send `Authorization: Bearer <hf_token>`; or wire "Sign in with HF"
+  OAuth. Choose deliberately — a public MCP endpoint with a baked-in default
+  token acts on that token's behalf for any caller.
+
+## 7. Operational notes
+
+- **Cold starts**: free CPU Spaces sleep after inactivity; set `sleep_time` or
+  use paid hardware. First request after sleep is slow — clients may time out.
+- **Stateless**: Spaces restart/scale; keep no in-memory state you can't lose,
+  or persist to a mounted volume/bucket.
+- **Logs/build**: watch the build + runtime logs (`hf spaces logs <space>
+  [--build]`) — `BUILD_ERROR` usually means the Dockerfile; a running container
+  that won't connect usually means `app_port`.
+
+## Smoke test
+
+Minimal MCP `initialize` over HTTP (add `Authorization: Bearer <token>` for a
+private Space), confirm `serverInfo` + capabilities, then `tools/list` (and
+`resources/list` if applicable). The MCP Inspector or a real client
+(Claude Desktop, fast-agent) works too — but note some clients only consume
+tools, not resources/skills.


### PR DESCRIPTION
Adds a skill covering how to **deploy/host an MCP server on Hugging Face Spaces** — a gap in the current catalog (there are good HF docs for this, but no skill).

### Contents
`skills/deploy-mcp-server-on-hf/`
- **SKILL.md** — a decision matrix (Gradio Space with native MCP vs Docker Space for any HTTP/SSE server vs proxying an existing Space), both paths **pointer-led to the official docs** (Gradio MCP guide, MCP course, Spaces-as-MCP, Docker Spaces), plus a verify section.
- **references/docker-space-mcp.md** — the concrete Docker recipe (Dockerfile shape + README `app_port` metadata + deploy/secrets/volume steps). This generic 'package any MCP server as a Docker Space' flow isn't written up as MCP guidance anywhere, so it's spelled out here.

### Design
Follows the catalog's pointer-led style: links the canonical docs rather than duplicating them. The value-add is the under-documented Docker-Space path and the operational gotchas that bite in practice — `app_port` routing (the 'builds but won't connect' trap), Streamable-HTTP/SSE/no-stdio, private-Space `Authorization: Bearer` auth, secrets vs variables, bucket volume mounts, and cold starts.

Multi-file, so it builds into a `.tar.gz` archive entry; verified locally with `scripts/build_skill_distribution.py` (valid `archive` entry in `index.json`).