### PR TITLE
fix: add hf-mem marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Agent Skills for AI/ML tasks including dataset creation, model training, evaluation, and research paper publishing on Hugging Face Hub",
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   "plugins": [
     {
@@ -49,6 +49,12 @@
       "source": "./skills/hf-cli",
       "skills": "./",
       "description": "Execute Hugging Face Hub operations using the hf CLI. Download models/datasets, upload files, manage repos, and run cloud compute jobs."
+    },
+    {
+      "name": "hf-mem",
+      "source": "./skills/hf-mem",
+      "skills": "./",
+      "description": "Estimate memory requirements for Hugging Face Safetensors and GGUF model weights, including optional KV cache estimates for inference planning."
     },
     {
       "name": "huggingface-spaces",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Agent Skills for AI/ML tasks including dataset creation, model training, evaluation, and research paper publishing on Hugging Face Hub",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": {
     "name": "Hugging Face"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Agent Skills for AI/ML tasks including dataset creation, model training, evaluation, and research paper publishing on Hugging Face Hub",
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "skills": "skills",
   "mcpServers": ".mcp.json",
   "description": "Agent Skills for AI/ML tasks including dataset creation, model training, evaluation, and research paper publishing on Hugging Face Hub",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": {
     "name": "Hugging Face"
   },

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This repository contains a few skills to get you started. You can also contribut
 | Name | Description | Documentation |
 |------|-------------|---------------|
 | `hf-cli` | Execute Hugging Face Hub operations using the hf CLI. Download models/datasets, upload files, manage repos, and run cloud compute jobs. | [SKILL.md](skills/hf-cli/SKILL.md) |
+| `hf-mem` | Estimate memory requirements for Hugging Face Safetensors and GGUF model weights, including optional KV cache estimates for inference planning. | [SKILL.md](skills/hf-mem/SKILL.md) |
 | `huggingface-best` | Find the best AI model for any task by querying Hugging Face leaderboards and benchmarks. Recommends top models based on task type, hardware constraints, and benchmark scores. | [SKILL.md](skills/huggingface-best/SKILL.md) |
 | `huggingface-community-evals` | Add and manage evaluation results in Hugging Face model cards. Supports extracting eval tables from README content, importing scores from Artificial Analysis API, and running custom evaluations with vLLM/lighteval. | [SKILL.md](skills/huggingface-community-evals/SKILL.md) |
 | `huggingface-datasets` | Explore, query, and extract data from any Hugging Face dataset using the Dataset Viewer REST API and npx tooling. Zero Python dependencies — covers split/config discovery, row pagination, text search, filtering, SQL via parquetlens, and dataset upload via CLI. | [SKILL.md](skills/huggingface-datasets/SKILL.md) |

--- a/agentsmd/AGENTS.md
+++ b/agentsmd/AGENTS.md
@@ -4,6 +4,7 @@ You have additional SKILLs documented in directories containing a "SKILL.md" fil
 
 These skills are:
  - hf-cli -> "skills/hf-cli/SKILL.md"
+ - hf-mem -> "skills/hf-mem/SKILL.md"
  - huggingface-best -> "skills/huggingface-best/SKILL.md"
  - huggingface-community-evals -> "skills/huggingface-community-evals/SKILL.md"
  - huggingface-datasets -> "skills/huggingface-datasets/SKILL.md"
@@ -27,6 +28,7 @@ IMPORTANT: You MUST read the SKILL.md file whenever the description of the skill
 <available_skills>
 
 hf-cli: `"Hugging Face Hub CLI (`hf`) for downloading, uploading, and managing models, datasets, spaces, buckets, repos, papers, jobs, and more on the Hugging Face Hub. Use when: handling authentication; managing local cache; managing Hugging Face Buckets; running or scheduling jobs on Hugging Face infrastructure; managing Hugging Face repos; discussions and pull requests; browsing models, datasets and spaces; reading, searching, or browsing academic papers; managing collections; querying datasets; configuring spaces; setting up webhooks; or deploying and managing HF Inference Endpoints. Make sure to use this skill whenever the user mentions 'hf', 'huggingface', 'Hugging Face', 'huggingface-cli', or 'hugging face cli', or wants to do anything related to the Hugging Face ecosystem and to AI and ML in general. Also use for cloud storage needs like training checkpoints, data pipelines, or agent traces. Use even if the user doesn't explicitly ask for a CLI command. Replaces the deprecated `huggingface-cli`."`
+hf-mem: `Hugging Face CLI to estimate the required memory to load Safetensors or GGUF model weights for inference from the Hugging Face Hub`
 huggingface-best: `>`
 huggingface-community-evals: `Run evaluations for Hugging Face Hub models using inspect-ai and lighteval on local hardware. Use for backend selection, local GPU evals, and choosing between vLLM / Transformers / accelerate. Not for HF Jobs orchestration, model-card PRs, .eval_results publication, or community-evals automation.`
 huggingface-datasets: `Use this skill for Hugging Face Dataset Viewer API workflows that fetch subset/split metadata, paginate rows, search text, apply filters, download parquet URLs, and read size or statistics.`

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Provides access to the Hugging Face Skills.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "contextFileName": "agentsmd/AGENTS.md",
   "mcpServers": {
     "huggingface-skills": {


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

`hf-mem` exists in the repository, but it was missing from the plugin marketplace manifest.
That made the generated artifact check fail because every skill folder needs a matching marketplace entry.
This change registers `hf-mem` and regenerates the published metadata.

## What Changed

The fix adds `hf-mem` to the Claude plugin marketplace and lets the repository generator update the derived files.
The plugin package version moved from `1.0.8` to `1.0.9` because marketplace-visible content changed.

- Added the `hf-mem` entry to `.claude-plugin/marketplace.json`.
- Regenerated the README skill table and bundled agent/plugin metadata.
- Updated generated plugin manifest versions to `1.0.9`.

## Testing

I ran the same generated artifact validation used by the repository workflow.
It now passes with `hf-mem` included.

- `./scripts/publish.sh --check`
- `git diff --check`

## Risks

Risk is low.
This only registers an already-merged skill and updates generated metadata from the existing publish script.

Follow-up to #168.
