### PR TITLE
fix(huggingface-vision-trainer): correct stale skill references

### DIFF
--- a/skills/huggingface-vision-trainer/SKILL.md
+++ b/skills/huggingface-vision-trainer/SKILL.md
@@ -21,8 +21,7 @@ Use this skill when users want to:
 
 ## Related Skills
 
-- **`hugging-face-jobs`** — General HF Jobs infrastructure: token authentication, hardware flavors, timeout management, cost estimation, secrets, environment variables, scheduled jobs, and result persistence. **Refer to the Jobs skill for any non-training-specific Jobs questions** (e.g., "how do secrets work?", "what hardware is available?", "how do I pass tokens?").
-- **`hugging-face-model-trainer`** — TRL-based language model training (SFT, DPO, GRPO). Use that skill for text/language model fine-tuning.
+- **`huggingface-llm-trainer`** — General HF Jobs infrastructure (token authentication, hardware flavors, timeout management, cost estimation, secrets, environment variables, scheduled jobs, result persistence) and TRL-based language model training (SFT, DPO, GRPO). **Refer to this skill for any non-training-specific Jobs questions** (e.g., "how do secrets work?", "what hardware is available?", "how do I pass tokens?") and for text/language model fine-tuning.
 
 ## Local Script Execution
 
@@ -243,7 +242,7 @@ If you write a custom script, you MUST include this token injection before the `
 
 - Do NOT call `login()` in custom scripts unless replicating the full pattern from `scripts/object_detection_training.py`
 - Do NOT rely on implicit token resolution (`hub_token=None`) — unreliable in Jobs
-- See the `hugging-face-jobs` skill → *Token Usage Guide* for full details
+- See the `huggingface-llm-trainer` skill → *Token Usage Guide* for full details
 
 ### 3. JobInfo attribute
 
@@ -360,7 +359,7 @@ Start with `facebook/sam2.1-hiera-small` for fast iteration. SAM2 models are gen
 
 All recommended OD and IC models are under 100M params — **`t4-small` (16 GB VRAM, $0.40/hr) is sufficient for all of them.** Image classification models are generally smaller and faster than object detection models — `t4-small` handles even ViT-Base comfortably. For SAM2 models up to `hiera-base-plus`, `t4-small` is sufficient since only the mask decoder is trained. For `sam2.1-hiera-large` or SAM v1 models, use `l4x1` or `a10g-large`. Only upgrade if you hit OOM from large batch sizes — reduce batch size first before switching hardware. Common upgrade path: `t4-small` → `l4x1` ($0.80/hr, 24 GB) → `a10g-large` ($1.50/hr, 24 GB).
 
-For full hardware flavor list: refer to the `hugging-face-jobs` skill. For cost estimation: run `scripts/estimate_cost.py`.
+For full hardware flavor list: refer to the `huggingface-llm-trainer` skill. For cost estimation: run `scripts/estimate_cost.py`.
 
 ## Quick start — Object Detection
 

--- a/skills/huggingface-vision-trainer/references/hub_saving.md
+++ b/skills/huggingface-vision-trainer/references/hub_saving.md
@@ -254,7 +254,7 @@ trainer.push_to_hub()
 
 ## Authentication Methods
 
-For a complete guide on token types, `$HF_TOKEN` automatic replacement, `secrets` vs `env` differences, and security best practices, see the `hugging-face-jobs` skill → *Token Usage Guide*.
+For a complete guide on token types, `$HF_TOKEN` automatic replacement, `secrets` vs `env` differences, and security best practices, see the `huggingface-llm-trainer` skill → *Token Usage Guide*.
 
 **Recommended:** Always pass tokens via `secrets` (encrypted server-side):
 


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `SKILL.md` and `references/hub_saving.md` reference skills named `hugging-face-jobs` and `hugging-face-model-trainer`, neither of which exists in this repo.

**Evidence**: `ls skills/ | grep -iE 'jobs|model-trainer'` returns no matches; the actual HF-Jobs/TRL-training skill is `huggingface-llm-trainer`.

**Fix**: Repoints all four references (SKILL.md lines 24-25, 245, 362; hub_saving.md line 257) to `huggingface-llm-trainer`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:55377d37a6dffb98a966b267b0a0fd1a356361540a649070cd92c60a44c012a3"},{"rule_id":"BUG-broken-reference","fingerprint":"sha256:ad46c8ad82c634a746114cd6c26c1de01e551a5eb012bafb78c28861f4d6f769"}]}
nlpm-metadata-end -->
