### PR TITLE
fix(huggingface-community-evals): correct stale skill references

### DIFF
--- a/skills/huggingface-community-evals/SKILL.md
+++ b/skills/huggingface-community-evals/SKILL.md
@@ -21,7 +21,7 @@ It does **not** cover:
 - `.eval_results` generation or publishing
 - PR creation or community-evals automation
 
-If the user wants to **run the same eval remotely on Hugging Face Jobs**, hand off to the `hugging-face-jobs` skill and pass it one of the local scripts in this skill.
+If the user wants to **run the same eval remotely on Hugging Face Jobs**, hand off to the `huggingface-llm-trainer` skill and pass it one of the local scripts in this skill.
 
 If the user wants to **publish results into the community evals workflow**, stop after generating the evaluation run and hand off that publishing step to `~/code/community-evals`.
 
@@ -50,7 +50,7 @@ nvidia-smi
 
 If `nvidia-smi` is unavailable, either:
 - use `scripts/inspect_eval_uv.py` for lighter provider-backed evaluation, or
-- hand off to the `hugging-face-jobs` skill if the user wants remote compute.
+- hand off to the `huggingface-llm-trainer` skill if the user wants remote compute.
 
 # Core Workflow
 
@@ -64,7 +64,7 @@ If `nvidia-smi` is unavailable, either:
    - `inspect-ai`: add `--limit 10` or similar.
    - `lighteval`: add `--max-samples 10`.
 4. Scale up only after the smoke test passes.
-5. If the user wants remote execution, hand off to `hugging-face-jobs` with the same script + args.
+5. If the user wants remote execution, hand off to `huggingface-llm-trainer` with the same script + args.
 
 # Quick Start
 
@@ -144,7 +144,7 @@ If the user wants to:
 - schedule recurring runs
 - inspect / cancel / monitor jobs
 
-then switch to the **`hugging-face-jobs`** skill and pass it one of these scripts plus the chosen arguments.
+then switch to the **`huggingface-llm-trainer`** skill and pass it one of these scripts plus the chosen arguments.
 
 # Task Selection
 
@@ -179,7 +179,7 @@ Multiple `lighteval` tasks can be comma-separated in `--tasks`.
 |---|---|
 | `< 3B` | consumer GPU / Apple Silicon / small dev GPU |
 | `3B - 13B` | stronger local GPU |
-| `13B+` | high-memory local GPU or hand off to `hugging-face-jobs` |
+| `13B+` | high-memory local GPU or hand off to `huggingface-llm-trainer` |
 
 For smoke tests, prefer cheaper local runs plus `--limit` or `--max-samples`.
 
@@ -189,7 +189,7 @@ For smoke tests, prefer cheaper local runs plus `--limit` or `--max-samples`.
   - reduce `--batch-size`
   - reduce `--gpu-memory-utilization`
   - switch to a smaller model for the smoke test
-  - if necessary, hand off to `hugging-face-jobs`
+  - if necessary, hand off to `huggingface-llm-trainer`
 - Model unsupported by `vllm`:
   - switch to `--backend hf` for `inspect-ai`
   - switch to `--backend accelerate` for `lighteval`

--- a/skills/huggingface-community-evals/examples/USAGE_EXAMPLES.md
+++ b/skills/huggingface-community-evals/examples/USAGE_EXAMPLES.md
@@ -17,7 +17,7 @@ This document provides practical examples for **running evaluations locally** ag
 - model-card PR creation
 - Hugging Face Jobs orchestration
 
-If you want to run these same scripts remotely, use the `hugging-face-jobs` skill and pass one of the scripts in `scripts/`.
+If you want to run these same scripts remotely, use the `huggingface-llm-trainer` skill and pass one of the scripts in `scripts/`.
 
 ## Setup
 
@@ -98,4 +98,4 @@ uv run scripts/lighteval_vllm_uv.py \
 
 ## Hand-off to Hugging Face Jobs
 
-When local hardware is not enough, switch to the `hugging-face-jobs` skill and run one of these scripts remotely. Keep the script path and args; move the orchestration there.
+When local hardware is not enough, switch to the `huggingface-llm-trainer` skill and run one of these scripts remotely. Keep the script path and args; move the orchestration there.


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `SKILL.md` and `examples/USAGE_EXAMPLES.md` reference a skill named `hugging-face-jobs`, which doesn't exist in this repo.

**Evidence**: `ls skills/ | grep -i jobs` returns no matches; the actual HF-Jobs remote-execution skill is `huggingface-llm-trainer`.

**Fix**: Repoints all eight references (SKILL.md lines 24, 53, 67, 147, 182, 192; USAGE_EXAMPLES.md lines 20, 101) to `huggingface-llm-trainer`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:257f62ee3c180d4a0661e7579b30bcc1a412e7829a0fb87c395fd513361965f3"},{"rule_id":"BUG-broken-reference","fingerprint":"sha256:ebbe16097a8bd6a7fd4864e9161a077becc4769bbc53a4eb26908afac74ffd43"}]}
nlpm-metadata-end -->
