### PR TITLE
ci: add ClawHub bulk skill publish workflow

### DIFF
--- a/.github/workflows/publish-clawhub-skills.yml
+++ b/.github/workflows/publish-clawhub-skills.yml
@@ -1,0 +1,62 @@
+name: Publish ClawHub skills
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: ClawHub owner to publish under.
+        required: true
+        type: string
+        default: huggingface
+      tags:
+        description: Tags to apply to each published version.
+        required: false
+        type: string
+        default: latest
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - skill_id: hf-mem
+            display_name: Hugging Face Memory Estimator
+            clawscan_note: Estimates Hugging Face model memory from Hub metadata and HTTP range requests. Network access is expected for Hugging Face Hub metadata and model file headers; gated or private models may require HF_TOKEN.
+          - skill_id: huggingface-local-models
+            display_name: Hugging Face Local Models
+            clawscan_note: Helps select and run local Hugging Face models with llama.cpp, GGUF, and OpenAI-compatible local servers. It may suggest downloading models and installing local inference runtimes.
+          - skill_id: huggingface-spaces
+            display_name: Hugging Face Spaces
+            clawscan_note: Helps create, deploy, and debug Hugging Face Spaces. It may edit app files, run local checks, and use authenticated Hugging Face CLI or API calls to manage Spaces.
+          - skill_id: huggingface-zerogpu
+            display_name: Hugging Face ZeroGPU
+            clawscan_note: Provides guidance for Gradio Spaces on ZeroGPU hardware. It may edit Space app code and configuration related to @spaces.GPU, dependencies, and runtime constraints.
+          - skill_id: huggingface-gradio
+            display_name: Hugging Face Gradio
+            clawscan_note: Helps build and modify Gradio applications. It may install Python dependencies, run local demo servers, and interact with Hugging Face services when requested.
+          - skill_id: huggingface-datasets
+            display_name: Hugging Face Datasets
+            clawscan_note: Uses Hugging Face Dataset Viewer and Hub APIs for dataset discovery, row access, filtering, parquet inspection, and related dataset workflows. Most operations are read-only unless upload commands are requested.
+          - skill_id: huggingface-papers
+            display_name: Hugging Face Papers
+            clawscan_note: Reads Hugging Face paper pages and paper API metadata. Network access is expected for Hugging Face paper, model, dataset, and Space metadata.
+          - skill_id: transformers-js
+            display_name: Transformers.js
+            clawscan_note: Helps build JavaScript and TypeScript applications with Transformers.js. It may download model assets from the Hugging Face Hub and install Node.js dependencies when requested.
+          - skill_id: huggingface-lora-space-builder
+            display_name: Hugging Face LoRA Space Builder
+            clawscan_note: Builds and publishes Gradio Spaces for LoRA models. It may create or update Space repositories, edit app files, install Python dependencies, and use authenticated Hugging Face CLI or API calls.
+    uses: ./.github/workflows/publish-single-clawhub-skill.yml
+    with:
+      skill_id: ${{ matrix.skill_id }}
+      owner: ${{ inputs.owner }}
+      slug: ${{ matrix.skill_id }}
+      display_name: ${{ matrix.display_name }}
+      tags: ${{ inputs.tags }}
+      clawscan_note: ${{ matrix.clawscan_note }}
+    secrets:
+      CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}

--- a/.github/workflows/publish-single-clawhub-skill.yml
+++ b/.github/workflows/publish-single-clawhub-skill.yml
@@ -1,10 +1,10 @@
-name: Publish skill to ClawHub
+name: Publish single ClawHub skill
 
 on:
   workflow_dispatch:
     inputs:
       skill_id:
-        description: Skill id to regenerate from the Hugging Face CLI.
+        description: Skill id to install from the Hugging Face skills marketplace.
         required: true
         type: string
         default: hf-cli
@@ -24,7 +24,7 @@ on:
         type: string
         default: ""
       version:
-        description: Version override. Defaults to the generated skill version when empty.
+        description: Version override. Defaults to the hf-cli version for hf-cli and the repo skill bundle version for other skills.
         required: false
         type: string
         default: ""
@@ -46,7 +46,7 @@ on:
   workflow_call:
     inputs:
       skill_id:
-        description: Skill id to regenerate from the Hugging Face CLI.
+        description: Skill id to install from the Hugging Face skills marketplace.
         required: true
         type: string
       owner:
@@ -65,7 +65,7 @@ on:
         type: string
         default: ""
       version:
-        description: Version override. Defaults to the generated skill version when empty.
+        description: Version override. Defaults to the hf-cli version for hf-cli and the repo skill bundle version for other skills.
         required: false
         type: string
         default: ""
@@ -136,7 +136,7 @@ jobs:
           echo "slug=$slug" >> "$GITHUB_OUTPUT"
           echo "display_name=$display_name" >> "$GITHUB_OUTPUT"
 
-      - name: Regenerate skill
+      - name: Install skill contents
         env:
           SKILL_ID: ${{ steps.publish-inputs.outputs.skill_id }}
         run: |
@@ -161,19 +161,31 @@ jobs:
 
           version="$(python3 - <<'PY'
           import os
+          import json
           import re
           import subprocess
           from pathlib import Path
 
           skill_id = os.environ["SKILL_ID"]
-          hf_version = subprocess.check_output(["hf", "--version"], text=True).strip().splitlines()[-1].strip()
-          if hf_version:
-              print(hf_version)
-          else:
+          if skill_id == "hf-cli":
+              hf_version = subprocess.check_output(["hf", "--version"], text=True).strip().splitlines()[-1].strip()
+              if hf_version:
+                  print(hf_version)
+                  raise SystemExit
+
               text = (Path("skills") / skill_id / "SKILL.md").read_text(encoding="utf-8")
               match = re.search(r"Generated with `huggingface_hub v([^`]+)`", text)
               if match:
                   print(match.group(1).strip())
+                  raise SystemExit
+
+              raise RuntimeError("Could not resolve hf-cli version from `hf --version` or generated SKILL.md.")
+
+          marketplace = json.loads(Path(".claude-plugin/marketplace.json").read_text(encoding="utf-8"))
+          version = marketplace.get("metadata", {}).get("version")
+          if not version:
+              raise RuntimeError("Could not resolve skill bundle version from .claude-plugin/marketplace.json.")
+          print(version)
           PY
           )"
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -207,7 +219,11 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "$CHANGELOG" ]]; then
-            CHANGELOG="Sync $SKILL_ID skill from Hugging Face CLI $VERSION"
+            if [[ "$SKILL_ID" == "hf-cli" ]]; then
+              CHANGELOG="Sync $SKILL_ID skill from Hugging Face CLI $VERSION"
+            else
+              CHANGELOG="Publish $SKILL_ID skill from Hugging Face Skills $VERSION"
+            fi
           fi
 
           if [[ -z "$CLAWSCAN_NOTE" && "$SKILL_ID" == "hf-cli" ]]; then


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Only `hf-cli` has a direct ClawHub publish path today.
This change adds one manual workflow that publishes the recommended Hugging Face skills to ClawHub in a single matrix run.
It also makes the reusable single-skill publisher choose the right default version: `hf-cli` keeps using the HF CLI version, while other skills use the repo skill bundle version.

## What Changed

The existing single-skill workflow is now generic enough for static skills.
The new bulk workflow calls that reusable workflow once per selected skill, with display names and ClawScan notes for each publish.

- Added `.github/workflows/publish-recommended-clawhub-skills.yml`.
- Publishes these skills in one dispatch: `hf-mem`, `huggingface-local-models`, `huggingface-spaces`, `huggingface-zerogpu`, `huggingface-gradio`, `huggingface-datasets`, `huggingface-papers`, `transformers-js`, and `huggingface-lora-space-builder`.
- Updated `publish-clawhub-skill.yml` so non-`hf-cli` skills default to `.claude-plugin/marketplace.json` metadata version instead of `hf --version`.
- Updated the default changelog text for non-`hf-cli` skills.

## Testing

I validated the workflow files and checked that every selected skill can be installed through the same `hf skills add` command used by the publish job.
I did not trigger the new publish workflow from this branch.

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-recommended-clawhub-skills.yml"); YAML.load_file(".github/workflows/publish-clawhub-skill.yml"); puts "yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/publish-clawhub-skill.yml .github/workflows/publish-recommended-clawhub-skills.yml`
- `uv run scripts/plugin_versions.py check-bump origin/main`
- `hf skills add <skill> --dest <tmp> --force` for all 9 selected skills
- `git diff --check`

## Risks

The main risk is publishing metadata quality, not code execution.
Each selected skill has an explicit ClawScan note, and the workflow still skips a publish if the same slug and version already exists on ClawHub.

The workflow requires the existing `CLAWHUB_TOKEN` secret, same as the current single-skill publisher.
