### PR TITLE
Fix TRL Jobs Hub push example

### DIFF
--- a/.claude-plugin/marketplace-internal.json
+++ b/.claude-plugin/marketplace-internal.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Full Hugging Face Skills manifest for hf skills, MCP, and discovery. Client plugin marketplaces use curated manifests.",
-    "version": "1.0.13"
+    "version": "1.0.14"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-    "version": "1.0.13"
+    "version": "1.0.14"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": {
     "name": "Hugging Face"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-    "version": "1.0.13"
+    "version": "1.0.14"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "skills": "skills",
   "mcpServers": ".mcp.json",
   "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": {
     "name": "Hugging Face"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Provides access to the Hugging Face Skills.",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "contextFileName": "agentsmd/AGENTS.md",
   "mcpServers": {
     "huggingface-skills": {

--- a/skills/huggingface-llm-trainer/SKILL.md
+++ b/skills/huggingface-llm-trainer/SKILL.md
@@ -330,13 +330,16 @@ hf jobs cancel <job-id>           # Cancel a job
 The `trl-jobs` package provides optimized defaults and one-liner training.
 
 ```bash
-uvx trl-jobs sft \
+HF_TOKEN=hf_xxx uvx trl-jobs sft \
   --model_name Qwen/Qwen2.5-0.5B \
-  --dataset_name trl-lib/Capybara
-
+  --dataset_name trl-lib/Capybara \
+  --push_to_hub true \
+  --hub_model_id username/qwen-capybara-sft
 ```
 
-**Benefits:** Pre-configured settings, automatic Trackio integration, automatic Hub push, one-line commands
+`trl-jobs` forwards extra arguments to `trl sft`, so keep `push_to_hub` and `hub_model_id` explicit unless you have verified a bundled `trl-jobs` config already sets them. It also forwards the current token to the remote Job as `HF_TOKEN`; provide a write token with `HF_TOKEN`, `huggingface-cli login`, or `--token` so the model can be pushed before the Jobs filesystem is cleaned up.
+
+**Benefits:** Pre-configured settings, automatic Trackio integration, automatic Hub push when authenticated, one-line commands
 **When to use:** User working in terminal directly (not Claude Code context), quick local experimentation
 **Repository:** https://github.com/huggingface/trl-jobs
 


### PR DESCRIPTION
## Summary

Fixes #173.

Approach 4 in `huggingface-llm-trainer` now keeps the same Hub-push contract documented elsewhere in the skill:

- passes a write token through `HF_TOKEN`
- sets `--push_to_hub true`
- sets an explicit `--hub_model_id`
- clarifies that `trl-jobs` forwards extra args to `trl sft` and needs an authenticated token for the remote Job to push before the ephemeral filesystem is cleaned up

The skill bundle version was bumped from `1.0.13` to `1.0.14` with `./scripts/publish.sh`.

## Testing

- `UV_CACHE_DIR=/Users/haoqian/Documents/Codex/2026-07-07/https-linear-app-dark-legion-issue-12/work/.uv-cache UV_PYTHON_INSTALL_DIR=/Users/haoqian/Documents/Codex/2026-07-07/https-linear-app-dark-legion-issue-12/work/.uv-python ./scripts/publish.sh`
- `UV_CACHE_DIR=/Users/haoqian/Documents/Codex/2026-07-07/https-linear-app-dark-legion-issue-12/work/.uv-cache UV_PYTHON_INSTALL_DIR=/Users/haoqian/Documents/Codex/2026-07-07/https-linear-app-dark-legion-issue-12/work/.uv-python ./scripts/publish.sh --check`
- `git diff --check`

## Risks

Low. This is a documentation-only skill example update plus the required generated manifest version bump.
