### PR TITLE
huggingface-spaces: prefer OAuth browser login in setup

### DIFF
--- a/.claude-plugin/marketplace-internal.json
+++ b/.claude-plugin/marketplace-internal.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Full Hugging Face Skills manifest for hf skills, MCP, and discovery. Client plugin marketplaces use curated manifests.",
-    "version": "1.0.16"
+    "version": "1.0.17"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-    "version": "1.0.16"
+    "version": "1.0.17"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": {
     "name": "Hugging Face"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-    "version": "1.0.16"
+    "version": "1.0.17"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "skills": "skills",
   "mcpServers": ".mcp.json",
   "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": {
     "name": "Hugging Face"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Provides access to the Hugging Face Skills.",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "contextFileName": "agentsmd/AGENTS.md",
   "mcpServers": {
     "huggingface-skills": {

--- a/skills/huggingface-spaces/README.md
+++ b/skills/huggingface-spaces/README.md
@@ -1,9 +1,9 @@
 # Hugging Face Spaces skill
 
-To add the Hugging Face Space creation skill for your agent, [Install the hf CLI](https://huggingface.co/docs/huggingface_hub/guides/cli#getting-started) and run
+To add the Hugging Face Space creation skill for your agent, [Install the hf CLI](https://huggingface.co/docs/huggingface_hub/guides/cli#getting-started), login with `hf auth login` and run
 
 ```
 hf skills add huggingface-spaces --claude --global
 ```
 
-Or just point your agent to https://github.com/huggingface/skills/tree/main/skills/huggingface-spaces and it will know what to do
+Or just point your agent here https://github.com/huggingface/skills/tree/main/skills/huggingface-spaces and it will know what to do

--- a/skills/huggingface-spaces/SKILL.md
+++ b/skills/huggingface-spaces/SKILL.md
@@ -12,7 +12,7 @@ Hugging Face Spaces host machine-learning applications. There are 1M+ today; eac
 Before anything else:
 
 1. Check the `hf` CLI is installed: `which hf`. If not, `pip install -U huggingface_hub`.
-2. Check the user is logged in: `hf auth whoami`. If not, ask them to run `! hf auth login` in this session — they'll need a write-scoped token from https://huggingface.co/settings/tokens.
+2. Check the user is logged in: `hf auth whoami`. If not, run `hf auth login` — it prints a URL and a one-time code; ask the user to open the URL and enter the code, then login completes automatically (OAuth, no token needed). Alternatively, pass a write-scoped token from https://huggingface.co/settings/tokens with `--token`.
 3. Note `whoami`'s `canPay` and `isPro` flags — they gate hardware choices below.
 
 The `hf-cli` skill teaches an agent every `hf` command and is the recommended companion to this one. Install it with `hf skills add hf-cli` (add `--claude --global` to install for Claude Code as well, user-level).


### PR DESCRIPTION
The login step told the agent to have the user run `! hf auth login` and supply a write-scoped token. With OAuth device login the agent can run `hf auth login` itself — it prints a URL + one-time code, the user completes it in the browser, and login finishes automatically. Token via `--token` kept as the alternative.