### PR TITLE
spaces: Gradio/Docker Spaces now need a paid plan; free accounts get 2 ZeroGPU Spaces

### DIFF
--- a/.claude-plugin/marketplace-internal.json
+++ b/.claude-plugin/marketplace-internal.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Full Hugging Face Skills manifest for hf skills, MCP, and discovery. Client plugin marketplaces use curated manifests.",
-    "version": "1.0.20"
+    "version": "1.0.21"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-    "version": "1.0.20"
+    "version": "1.0.21"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "author": {
     "name": "Hugging Face"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-    "version": "1.0.20"
+    "version": "1.0.21"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "skills": "skills",
   "mcpServers": ".mcp.json",
   "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "author": {
     "name": "Hugging Face"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Provides access to the Hugging Face Skills.",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "contextFileName": "agentsmd/AGENTS.md",
   "mcpServers": {
     "huggingface-skills": {

--- a/skills/huggingface-spaces/SKILL.md
+++ b/skills/huggingface-spaces/SKILL.md
@@ -13,7 +13,7 @@ Before anything else:
 
 1. Check the `hf` CLI is installed: `which hf`. If not, `pip install -U huggingface_hub`.
 2. Check the user is logged in: `hf auth whoami`. If not, run `hf auth login` — it prints a URL and a one-time code; ask the user to open the URL and enter the code, then login completes automatically (OAuth, no token needed). Alternatively, pass a write-scoped token from https://huggingface.co/settings/tokens with `--token`.
-3. Note `whoami`'s `canPay` and `isPro` flags — they gate hardware choices below.
+3. Note `whoami`'s `canPay` and `isPro` flags — they gate hardware choices below. A free (`isPro=False`) account can only host Static Spaces and up to 2 ZeroGPU Spaces.
 
 The `hf-cli` skill teaches an agent every `hf` command and is the recommended companion to this one. Install it with `hf skills add hf-cli` (add `--claude --global` to install for Claude Code as well, user-level).
 
@@ -27,15 +27,17 @@ A Space is a git repo with three possible SDKs:
 
 ### Hardware tiers
 
-Free, no creator cost: **`cpu-basic`** and **`zero-a10g`** (ZeroGPU). Static Spaces are also free and don't need hardware.
+Static Spaces are free for everyone and need no hardware. **Gradio and Docker Spaces run on compute and require a paid plan to create** — PRO for personal accounts, Team or Enterprise for organizations — with one exception: **free personal accounts in good standing (verified email, account older than 30 days) can host up to 2 ZeroGPU Spaces.**
 
-**`cpu-basic`** — 2 vCPU / 16 GB. For data viz, API-proxy Spaces, small CPU-bound models.
+So on a free account ZeroGPU is the *only* way to host a Gradio Space. `cpu-basic` is not the safe fallback it used to be — it is gated too.
 
-**ZeroGPU (`zero-a10g`)** — dynamic, per-request GPU allocation on NVIDIA RTX PRO 6000 Blackwell (sm_120). Two sizes: `large` (half MIG, 48 GB, 1× quota) and `xlarge` (full, 96 GB, 2× quota). Free for the Space creator; Space visitors consume their own daily quota (~5 min free / 40 min Pro / 60 min Enterprise). **Gradio-only**, **PyTorch-first**. Requires the creator to be on a PRO / Team / Enterprise plan.
+**ZeroGPU (`zero-a10g`)** — dynamic, per-request GPU allocation on NVIDIA RTX PRO 6000 Blackwell (sm_120). Two sizes: `large` (half MIG, 48 GB, 1× quota) and `xlarge` (full, 96 GB, 2× quota). Free for the Space creator; Space visitors consume their own daily quota (~5 min free / 40 min Pro / 60 min Enterprise). **Gradio-only**, **PyTorch-first**. Hosting caps per account: **2** free personal, **10** PRO, **50** Team / Enterprise org.
+
+**`cpu-basic`** — 2 vCPU / 16 GB, no hourly cost but needs a paid plan. For data viz, API-proxy Spaces, small CPU-bound models.
 
 **Dedicated GPU** (T4, L4, A10G, L40S, A100, H200) — billed to the Space creator by the hour. List + pricing: `hf spaces hardware`. Only the creator can attach these, and only if `canPay=True`. Use when ZeroGPU genuinely doesn't fit — non-PyTorch main model with heavy init, very-large-model long-context inference, etc.
 
-If a non-PRO user has a use case that wants ZeroGPU, you can still build it: create a `cpu-basic` Space, code the app for ZeroGPU, push, then request a community grant. See [`references/grants.md`](references/grants.md).
+If the user needs hardware they can't pay for — a dedicated GPU, or a Gradio Space beyond the free 2-ZeroGPU cap — they can still create a **Static** Space (free for everyone), push the app there, and request a community grant. See [`references/grants.md`](references/grants.md).
 
 For the authoritative reference: https://huggingface.co/docs/hub/spaces-overview
 
@@ -56,7 +58,7 @@ Follow the user's explicit request first. If they were vague:
 - **Default for a public ML demo**: Gradio + ZeroGPU. Use this unless something below applies.
 - **The model's only inference path is non-PyTorch** (ONNX / TF / JAX / vLLM as the MAIN model, with heavy init): dedicated GPU.
   - But: marginal non-torch tools (a small ONNX preprocessor, a TF utility) inside a torch-main pipeline are fine on ZeroGPU. The hijack only patches torch; init the non-torch lib inside `@spaces.GPU` and pay the short per-call init cost.
-- **Tiny / CPU-bound model, or API-proxy Space**: `cpu-basic` (`hardware`-free isn't applicable to Gradio).
+- **Tiny / CPU-bound model, or API-proxy Space**: `cpu-basic` — but it needs a paid plan. On a free account, put it on `zero-a10g` with a no-op decorated function (ZeroGPU requires at least one) and keep the real work outside it — nothing ever requests a GPU, so no quota is burned. See [`references/inference-providers.md`](references/inference-providers.md).
 - **Browser-side ML or project page**: Static.
 - **Container with non-Python stack**: Docker.
 
@@ -80,7 +82,7 @@ hf repos create <namespace>/<name> --type space --space-sdk <gradio|docker|stati
 ```
 
 - `--space-sdk` is required.
-- `--flavor` selects hardware. `zero-a10g` is the (legacy) identifier for ZeroGPU. Omit for `cpu-basic`. Run `hf spaces hardware` for the full paid list and pricing.
+- `--flavor` selects hardware. `zero-a10g` is the (legacy) identifier for ZeroGPU. Omitting it gives `cpu-basic` — which is itself gated behind a paid plan, so on a free account pass `--flavor zero-a10g` explicitly. Run `hf spaces hardware` for the full paid list and pricing.
 - Visibility: `--public` (anyone can view), `--private` (only you), `--protected` (app is reachable but git repo / Files tab is private).
 - `--secrets KEY=val` becomes an environment variable inside the Space and is **not** visible to visitors. Use for API keys, gated-repo tokens (`HF_TOKEN=hf_…`), etc. Can also be set later via `hf spaces secrets set <id> KEY=val`.
 - `--env KEY=val` is **visible to visitors** — use only for non-sensitive config (`GRADIO_SSR_MODE=false`, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`, etc.).
@@ -235,6 +237,6 @@ If you solve an error that wasn't in the known-errors list, suggest the user PR 
 | Pinning deps, picking wheels, torch-family alignment | [`references/requirements.md`](references/requirements.md) |
 | `gr.Examples` (add when it makes sense), themes, custom HTML components, `gr.Server`, MCP server (`mcp_server=True`) | [`references/gradio.md`](references/gradio.md) |
 | Persistent storage, public bucket URLs | [`references/buckets.md`](references/buckets.md) |
-| Community grant requests (non-PRO needing ZeroGPU) | [`references/grants.md`](references/grants.md) |
+| Community grant requests (hardware the user can't pay for) | [`references/grants.md`](references/grants.md) |
 | Provider proxy (zero-VRAM big LLM via Cerebras / Fireworks / Together / etc.) | [`references/inference-providers.md`](references/inference-providers.md) |
 | **3D Spaces: generation, CUDA extensions, output formats, and model recipes (incl. gaussian splatting)** | [`references/3d-generation.md`](references/3d-generation.md) |

--- a/skills/huggingface-spaces/references/grants.md
+++ b/skills/huggingface-spaces/references/grants.md
@@ -1,12 +1,19 @@
 # Community GPU grants
 
-When a non-PRO user has a good use case for ZeroGPU (open research demo, hobbyist project, educational tool, institutional showcase) and doesn't want to subscribe, they can request a free community grant from Hugging Face.
+When a user has a good use case (open research demo, hobbyist project, educational tool, institutional showcase) and can't pay for the hardware it needs, they can request a free community grant from Hugging Face.
+
+Free personal accounts already get 2 ZeroGPU Spaces, so a grant is now for the cases that go past that:
+
+- a **dedicated GPU** ZeroGPU can't cover (non-PyTorch main model with heavy init, model too big for 96 GB, always-on serving);
+- a **Gradio Space beyond the free 2-ZeroGPU cap**, without subscribing to PRO.
 
 ## The flow
 
-1. **Build the Space.** Create it as `--flavor cpu-basic` (the user is not PRO, so creating with `--flavor zero-a10g` will fail at `create_repo`). Code the app for ZeroGPU anyway — `import spaces`, `@spaces.GPU`, module-scope `.to("cuda")`. The Space will technically run on CPU until the grant is approved, but it'll be ready to switch over instantly.
+1. **Build the Space.** If the user still has a free ZeroGPU slot, create it as `--flavor zero-a10g` and iterate normally with real inference before applying.
 
-   In this mode you **can't iterate-with-real-inference** before the grant — the CPU Space won't actually run heavy compute. Get the app to BUILD cleanly and `RUNNING` (even if the runtime would OOM on real input), then submit.
+   If they're out of slots, create a **Static** Space instead (`--space-sdk static` — free for everyone) and push the app there; the SDK can be switched to `gradio` in the README frontmatter once the grant lands. Code the app for ZeroGPU anyway — `import spaces`, `@spaces.GPU`, module-scope `.to("cuda")`. In this mode you **can't iterate-with-real-inference** before the grant, so just get the code in place and submit.
+
+   For a dedicated-GPU grant, get the app to BUILD cleanly and reach `RUNNING` (even if the runtime would OOM on real input), then submit.
 
 2. **Submit a Community Tab discussion** on the Space. Title:
 
@@ -22,22 +29,22 @@ When a non-PRO user has a good use case for ZeroGPU (open research demo, hobbyis
    (open-source, research, educational, etc.). 
    ```
 
-   If the user didn't give you a justification, a reasonable default is "Non-PRO wants to build a public ZeroGPU app — happy to provide more context if helpful."
+   If the user didn't give you a justification, a reasonable default is "Public open-source demo, can't cover the hardware cost — happy to provide more context if helpful."
 
 3. **Wait.** Open and publicly-facing applications by researchers, tinkerers, and institutions are typically approved. Approval can take days.
 
-4. **Once approved**, the Space is moved to ZeroGPU automatically — no code change needed. The user comes back and you can iterate / refine with real GPU access.
+4. **Once approved**, the hardware is attached automatically — no code change needed (a Static holding Space still needs its `sdk:` flipped to `gradio`). The user comes back and you can iterate / refine with real GPU access.
 
 ## When to suggest this
 
-- User is not on PRO but their use case is a clear fit for ZeroGPU (a public ML demo, not a private tool).
-- The model fits in `large` (≤ 48 GB VRAM at the chosen precision).
+- The use case is a clear public ML demo (not a private tool) and the user is out of free ZeroGPU slots.
+- The model needs more than ZeroGPU offers — beyond 48 GB `large` / 96 GB `xlarge`, or a non-PyTorch runtime — and the user can't pay.
 
 ## When NOT to suggest this
 
+- The user is on a free account and this is their 1st or 2nd Space — they can create it on ZeroGPU directly; no grant needed.
 - Private / commercial / closed-source projects — push the user toward PRO instead.
-- The model genuinely needs dedicated paid hardware (huge LLM, vLLM/JAX/ONNX as main model with heavy init) — `canPay=True` users can use paid flavors directly.
-- The user is already PRO — they have ZeroGPU access; no grant needed.
+- `canPay=True` users who just need paid hardware — they can attach it directly.
 
 ## Posting the request programmatically
 

--- a/skills/huggingface-spaces/references/inference-providers.md
+++ b/skills/huggingface-spaces/references/inference-providers.md
@@ -2,9 +2,9 @@
 
 Some Spaces don't need a GPU at all. If the model is available through HF Inference Providers (Cerebras, Fireworks, Together, Replicate, OpenRouter, etc.), the Space can be a thin Gradio shell that proxies to a hosted endpoint:
 
-- Zero VRAM, no `@spaces.GPU`, no model download.
+- Zero VRAM, no real work inside `@spaces.GPU`, no model download.
 - Works for models too large to fit on ZeroGPU (120B+).
-- Hardware can be `cpu-basic` — no GPU at all.
+- No GPU at all — see [Hardware](#hardware) below for which flavor to pick.
 
 ## When to use this pattern
 
@@ -76,10 +76,22 @@ This is the **recommended pattern for public demos** — sustainable cost-wise, 
 
 ## Hardware
 
-`cpu-basic`. No GPU. Don't put `--flavor zero-a10g` — you'd waste a paid grant.
+No GPU needed, so `cpu-basic` is the natural fit — but it requires a paid plan.
+
+On a free account, create the Space with `--flavor zero-a10g` instead. ZeroGPU refuses to start without at least one decorated function, so add a no-op one and leave the provider calls outside it:
+
+```python
+import spaces
+
+@spaces.GPU(duration=1)
+def _noop():  # ZeroGPU requires ≥1 decorated function; never called
+    pass
+```
+
+Nothing ever requests a GPU, so no quota is burned. Just remember the Space still counts against the free 2-Space ZeroGPU cap — don't spend a slot here if the user is saving it for a real GPU demo.
 
 ## Anti-pattern: `@spaces.GPU` wrapping a provider call
 
 If you do use Inference Providers, do **not** wrap the call in `@spaces.GPU`. The decorator reserves a GPU slot on your Space for the full `duration=`, but the function does no GPU work — just an HTTP call out. You burn your own ZeroGPU quota for nothing.
 
-A provider-proxy Space wants `cpu-basic` hardware and zero `@spaces.GPU`.
+Whatever hardware a provider-proxy Space sits on, no provider call belongs inside `@spaces.GPU`.

--- a/skills/huggingface-spaces/references/known-errors.md
+++ b/skills/huggingface-spaces/references/known-errors.md
@@ -35,10 +35,10 @@ These come from the Space build pipeline before the app starts. Read with `hf sp
 **Cause**: README frontmatter failed server validation. Most common: `short_description` over the (undocumented) character cap — target ≤ 60.
 **Fix**: Shorten `short_description`. Long descriptions go in the README body. Also double-check `colorFrom`/`colorTo` are one of `red|yellow|green|blue|indigo|purple|pink|gray`.
 
-### `403 Forbidden` from `create_repo` with `space_hardware="zero-a10g"`
+### `403 Forbidden` from `create_repo` for a Gradio / Docker Space
 
-**Cause**: The user isn't on PRO / Team / Enterprise so the API rejects ZeroGPU at creation.
-**Fix**: Retry without `space_hardware=`. Keep `hardware:` out of README frontmatter (silently ignored anyway). The Space is created on CPU; point the user at PRO upgrade or [community grant](grants.md).
+**Cause**: Gradio and Docker Spaces run on compute and need a paid plan (PRO / Team / Enterprise). The only free exception is ZeroGPU — 2 Spaces for personal accounts in good standing (verified email, account older than 30 days).
+**Fix**: On a free account, pass `space_hardware="zero-a10g"` rather than omitting it — `cpu-basic` is gated too, so dropping the flavor makes this worse, not better. If ZeroGPU is also rejected, the account is over its 2-Space cap or not in good standing: delete an unused ZeroGPU Space, upgrade to PRO, or ship a Static Space and apply for a [community grant](grants.md). Keep `hardware:` out of README frontmatter (silently ignored anyway).
 
 ### `403 Forbidden` from `create_commit(..., create_pr=True)`
 


### PR DESCRIPTION
`cpu-basic` is no longer the free fallback — creating a Gradio or Docker Space
now requires PRO (personal) or Team/Enterprise (org). The exception is ZeroGPU:
free personal accounts in good standing can host up to 2.

The skill said the opposite ("create it as cpu-basic, the user is not PRO"), so
it steered free users to the one flavor they can't create.

- Hardware tiers rewritten; ZeroGPU hosting caps (2 / 10 / 50) added
- `--flavor`: pass `zero-a10g` on a free account, don't omit it
- grants.md: grants are now for dedicated GPUs or going past the 2-Space cap;
  holding pattern is a Static Space, not cpu-basic
- inference-providers.md: CPU-only proxy Spaces go on `zero-a10g` with a no-op
  decorated function (ZeroGPU needs ≥1) and no provider call inside it
- known-errors.md: 403 entry inverted accordingly

Refs https://huggingface.co/docs/hub/spaces-overview and /spaces-zerogpu
