### PR TITLE
Publish SEP-2640 per-file resource manifests

### DIFF
--- a/.github/workflows/generate-agents.yml
+++ b/.github/workflows/generate-agents.yml
@@ -3,9 +3,13 @@ name: Validate generated agent/plugin artifacts
 on:
   pull_request:
     paths:
+      - ".github/workflows/generate-agents.yml"
+      - ".github/workflows/sync-skills-to-bucket.yml"
       - "scripts/AGENTS_TEMPLATE.md"
       - "scripts/generate_agents.py"
       - "scripts/generate_cursor_plugin.py"
+      - "scripts/build_skill_distribution.py"
+      - "scripts/test_build_skill_distribution.py"
       - "scripts/plugin_versions.py"
       - "scripts/publish.sh"
       - "skills/**"
@@ -45,3 +49,13 @@ jobs:
             --repo-root . \
             --out-dir out/skills-index/latest \
             --branch main
+
+      - name: Test SEP-2640 skills catalog generation
+        run: uv run scripts/test_build_skill_distribution.py
+
+      - name: Ensure skills distribution artifact builds
+        run: |
+          uv run scripts/build_skill_distribution.py \
+            --skills-dir skills \
+            --out-dir out/skills-distribution/latest \
+            --uri-prefix skill://

--- a/.github/workflows/sync-skills-to-bucket.yml
+++ b/.github/workflows/sync-skills-to-bucket.yml
@@ -9,6 +9,7 @@ on:
       - ".claude-plugin/marketplace-internal.json"
       - "scripts/build_skills_index.py"
       - "scripts/build_skill_distribution.py"
+      - "scripts/test_build_skill_distribution.py"
       - ".github/workflows/sync-skills-to-bucket.yml"
 
 concurrency:
@@ -34,6 +35,7 @@ jobs:
 
       - name: Build skills distribution artifact
         run: |
+          uv run scripts/test_build_skill_distribution.py
           uv run scripts/build_skill_distribution.py \
             --skills-dir skills \
             --out-dir out/skills-distribution/latest \

--- a/scripts/build_skill_distribution.py
+++ b/scripts/build_skill_distribution.py
@@ -3,14 +3,19 @@
 # requires-python = ">=3.10"
 # dependencies = ["pyyaml==6.0.3"]
 # ///
-"""Build static skills distribution artifacts (SEP-2640 index format).
+"""Build static skills distribution artifacts.
 
 Single-file skills are emitted as ``<out>/<name>/SKILL.md`` for easy audit.
 Multi-file skills are emitted as ``<out>/<name>.tar.gz`` archives to keep the
-skill package atomic and avoid implying partial direct-resource support. The
-``index.json`` follows SEP-2640: each entry carries verbatim ``frontmatter`` plus
-either ``url`` + ``digest`` for direct ``SKILL.md`` entries, or an ``archives``
-array for archive-only entries.
+skill package atomic for legacy consumers. ``index.json`` retains the legacy
+archive-oriented format.
+
+``skills.json`` contains the current SEP-2640 skill-entry shape. Each entry has
+the URI of its ``SKILL.md``, its complete parsed frontmatter, and a ``resources``
+manifest containing the URI and raw-byte SHA-256 digest of every file in the
+published skill directory. All selected skill files are emitted under
+``<out>/<name>/``; the bucket sync workflow publishes that expanded tree and its
+manifest together.
 """
 
 from __future__ import annotations
@@ -27,6 +32,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import yaml
 
@@ -167,6 +173,36 @@ def uri_join(prefix: str, path: str) -> str:
 	return prefix.rstrip("/") + "/" + path
 
 
+def resource_uri(uri_prefix: str, skill_name: str, relative_path: str) -> str:
+	encoded_path = "/".join(quote(part, safe="") for part in relative_path.split("/"))
+	return uri_join(uri_prefix, f"{quote(skill_name, safe='')}/{encoded_path}")
+
+
+def write_skill_files(skill: Skill, out_dir: Path, uri_prefix: str) -> dict[str, Any]:
+	resources = []
+	for path in skill.files:
+		relative_path = rel_archive_path(skill.dir, path)
+		target = out_dir / skill.name / relative_path
+		target.parent.mkdir(parents=True, exist_ok=True)
+		shutil.copy2(path, target)
+		resources.append(
+			{
+				"uri": resource_uri(uri_prefix, skill.name, relative_path),
+				"digest": f"sha256:{sha256_hex(target)}",
+			}
+		)
+
+	skill_uri = resource_uri(uri_prefix, skill.name, "SKILL.md")
+	if not any(resource["uri"] == skill_uri for resource in resources):
+		raise ValueError(f"{skill.dir}: resource manifest does not include SKILL.md")
+
+	return {
+		"uri": skill_uri,
+		"frontmatter": skill.frontmatter,
+		"resources": resources,
+	}
+
+
 def build_distribution(skills_dir: Path, out_dir: Path, uri_prefix: str) -> None:
 	if out_dir.exists():
 		shutil.rmtree(out_dir)
@@ -174,9 +210,11 @@ def build_distribution(skills_dir: Path, out_dir: Path, uri_prefix: str) -> None
 
 	skills = load_skills(skills_dir)
 	index_entries: list[dict[str, Any]] = []
+	skill_entries: list[dict[str, Any]] = []
 	catalog_entries: list[dict[str, Any]] = []
 
 	for skill in skills:
+		skill_entries.append(write_skill_files(skill, out_dir, uri_prefix))
 		if len(skill.files) == 1 and skill.files[0].name == "SKILL.md":
 			skill_md_path = write_skill_md(skill, out_dir)
 			skill_md_url = uri_join(uri_prefix, f"{skill.name}/SKILL.md")
@@ -233,6 +271,7 @@ def build_distribution(skills_dir: Path, out_dir: Path, uri_prefix: str) -> None
 
 	generated_at = utc_now()
 	write_json(out_dir / "index.json", {"skills": index_entries})
+	write_json(out_dir / "skills.json", {"skills": skill_entries})
 	write_json(
 		out_dir / "ai-catalog.json",
 		{
@@ -256,6 +295,7 @@ def build_distribution(skills_dir: Path, out_dir: Path, uri_prefix: str) -> None
 			"uri_prefix": uri_prefix,
 			"artifacts": {
 				"skills_index": "index.json",
+				"skills_catalog": "skills.json",
 				"ai_catalog": "ai-catalog.json",
 			},
 		},

--- a/scripts/test_build_skill_distribution.py
+++ b/scripts/test_build_skill_distribution.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml==6.0.3"]
+# ///
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+from urllib.parse import unquote
+
+
+SCRIPT_PATH = Path(__file__).with_name("build_skill_distribution.py")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def load_builder() -> ModuleType:
+	spec = importlib.util.spec_from_file_location("build_skill_distribution", SCRIPT_PATH)
+	if spec is None or spec.loader is None:
+		raise RuntimeError(f"could not load {SCRIPT_PATH}")
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[spec.name] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+builder = load_builder()
+
+
+def write_skill(skill_dir: Path, description: str = "Test skill") -> None:
+	skill_dir.mkdir(parents=True)
+	(skill_dir / "SKILL.md").write_text(
+		f"---\nname: {skill_dir.name}\ndescription: {description}\nlicense: Apache-2.0\n---\n\n# Test\n",
+		encoding="utf-8",
+	)
+
+
+class BuildSkillDistributionTest(unittest.TestCase):
+	def test_writes_complete_sep_2640_resource_manifests(self) -> None:
+		with tempfile.TemporaryDirectory() as temp_dir:
+			root = Path(temp_dir)
+			skills_dir = root / "skills"
+			out_dir = root / "out"
+
+			single = skills_dir / "single"
+			write_skill(single, "Single-file skill")
+
+			multi = skills_dir / "multi"
+			write_skill(multi, "Multi-file skill")
+			(multi / "references").mkdir()
+			(multi / "references" / "guide.md").write_text("# Guide\r\n", encoding="utf-8", newline="")
+			(multi / "assets").mkdir()
+			binary_payload = b"line1\r\nline2\x00\xff\n"
+			(multi / "assets" / "raw data.bin").write_bytes(binary_payload)
+			(multi / "node_modules").mkdir()
+			(multi / "node_modules" / "ignored.js").write_text("ignored", encoding="utf-8")
+			(multi / ".DS_Store").write_bytes(b"ignored")
+
+			builder.build_distribution(skills_dir, out_dir, "skill://")
+
+			payload = json.loads((out_dir / "skills.json").read_text(encoding="utf-8"))
+			entries = {entry["frontmatter"]["name"]: entry for entry in payload["skills"]}
+			self.assertEqual(set(entries), {"multi", "single"})
+
+			for skill_name, expected_paths in {
+				"single": {"SKILL.md"},
+				"multi": {"SKILL.md", "assets/raw data.bin", "references/guide.md"},
+			}.items():
+				entry = entries[skill_name]
+				self.assertEqual(set(entry), {"uri", "frontmatter", "resources"})
+				self.assertEqual(entry["uri"], f"skill://{skill_name}/SKILL.md")
+				self.assertEqual(entry["frontmatter"]["license"], "Apache-2.0")
+
+				resources = entry["resources"]
+				self.assertEqual(len(resources), len(expected_paths))
+				self.assertEqual(len({resource["uri"] for resource in resources}), len(resources))
+				self.assertIn(entry["uri"], {resource["uri"] for resource in resources})
+
+				actual_paths = {
+					unquote(resource["uri"].split(f"skill://{skill_name}/", maxsplit=1)[1])
+					for resource in resources
+				}
+				self.assertEqual(actual_paths, expected_paths)
+
+				for resource in resources:
+					self.assertRegex(resource["digest"], DIGEST_RE)
+					relative_uri = resource["uri"].split(f"skill://{skill_name}/", maxsplit=1)[1]
+					relative_path = unquote(relative_uri)
+					source_bytes = (skills_dir / skill_name / relative_path).read_bytes()
+					published_path = out_dir / skill_name / relative_path
+					self.assertEqual(published_path.read_bytes(), source_bytes)
+					expected_digest = "sha256:" + hashlib.sha256(published_path.read_bytes()).hexdigest()
+					self.assertEqual(resource["digest"], expected_digest)
+
+			binary_resource = next(
+				resource for resource in entries["multi"]["resources"] if resource["uri"].endswith("raw%20data.bin")
+			)
+			self.assertEqual(binary_resource["digest"], "sha256:" + hashlib.sha256(binary_payload).hexdigest())
+			self.assertFalse((out_dir / "multi" / "node_modules").exists())
+			self.assertFalse((out_dir / "multi" / ".DS_Store").exists())
+
+			legacy = json.loads((out_dir / "index.json").read_text(encoding="utf-8"))
+			self.assertEqual(len(legacy["skills"]), 2)
+			self.assertTrue((out_dir / "multi.tar.gz").is_file())
+
+			manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+			self.assertEqual(manifest["artifacts"]["skills_catalog"], "skills.json")
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary

- add a generated `skills.json` catalog using the current SEP-2640 skill-entry shape (`uri`, complete `frontmatter`, and per-file `resources`)
- publish every selected skill file under `distribution/latest/<skill>/...` and hash the emitted raw bytes with SHA-256
- retain the existing `index.json` and archive outputs for backward compatibility during the MCP server migration
- add focused publisher tests and run them in PR and bucket-sync workflows

## Why

The current distribution implements an earlier SEP-2640 draft: single-file skills have one digest and multi-file skills are archive-only. The current draft requires every static skill to expose a complete manifest of individually addressable files and their raw-byte SHA-256 digests.

`skills.json` is intended as backing data for the MCP server's forthcoming `skills/list` and `skills/get` handlers. It is additive so the currently deployed server can continue consuming the legacy index until that migration lands.

## Generated result

A full repository build currently produces:

- 25 skill entries
- 154 individually addressable resources
- one matching SHA-256 digest for every emitted file

## Validation

- `uv run scripts/test_build_skill_distribution.py`
- `uv run scripts/build_skill_distribution.py --skills-dir skills --out-dir /tmp/skills-sep2640-build --uri-prefix skill://`
- independent verification that all 154 generated resource digests match the emitted bytes
- `./scripts/publish.sh --check`
- `git diff --check`

## Rollout note

The bucket does not provide snapshot versioning. The MCP consumer should therefore fetch `skills.json` and all listed files into a candidate in-memory snapshot, verify every digest, and atomically swap caches only after the complete snapshot validates. A failed/torn refresh should retain the previous snapshot and retry later.
