### PR TITLE
Publish Agent Skills discovery distribution

### DIFF
--- a/.github/workflows/generate-agents.yml
+++ b/.github/workflows/generate-agents.yml
@@ -50,7 +50,7 @@ jobs:
             --out-dir out/skills-index/latest \
             --branch main
 
-      - name: Test SEP-2640 skills catalog generation
+      - name: Test skills distribution generation
         run: uv run scripts/test_build_skill_distribution.py
 
       - name: Ensure skills distribution artifact builds
@@ -58,4 +58,6 @@ jobs:
           uv run scripts/build_skill_distribution.py \
             --skills-dir skills \
             --out-dir out/skills-distribution/latest \
-            --uri-prefix skill://
+            --uri-prefix skill:// \
+            --agent-skills-out-dir out/agent-skills-distribution/latest \
+            --agent-skills-public-base-url https://huggingface.co/buckets/huggingface/skills/resolve/agent-skills/latest

--- a/.github/workflows/sync-skills-to-bucket.yml
+++ b/.github/workflows/sync-skills-to-bucket.yml
@@ -39,7 +39,9 @@ jobs:
           uv run scripts/build_skill_distribution.py \
             --skills-dir skills \
             --out-dir out/skills-distribution/latest \
-            --uri-prefix skill://
+            --uri-prefix skill:// \
+            --agent-skills-out-dir out/agent-skills-distribution/latest \
+            --agent-skills-public-base-url https://huggingface.co/buckets/huggingface/skills/resolve/agent-skills/latest
 
       - name: Sync skills to bucket
         env:
@@ -49,3 +51,4 @@ jobs:
           uvx hf buckets cp ./.claude-plugin/marketplace-internal.json hf://buckets/huggingface/skills/marketplace.json
           uvx hf buckets sync ./out/skills-index/latest hf://buckets/huggingface/skills/index/latest --delete
           uvx hf buckets sync ./out/skills-distribution/latest hf://buckets/huggingface/skills/distribution/latest --delete
+          uvx hf buckets sync ./out/agent-skills-distribution/latest hf://buckets/huggingface/skills/agent-skills/latest --delete

--- a/scripts/build_skill_distribution.py
+++ b/scripts/build_skill_distribution.py
@@ -16,6 +16,10 @@ manifest containing the URI and raw-byte SHA-256 digest of every file in the
 published skill directory. All selected skill files are emitted under
 ``<out>/<name>/``; the bucket sync workflow publishes that expanded tree and its
 manifest together.
+
+When the Agent Skills output options are supplied, a separate v0.2 discovery
+index and its direct or archived artifacts are emitted without changing the
+legacy distribution.
 """
 
 from __future__ import annotations
@@ -42,6 +46,7 @@ IGNORE_DIRS = {"node_modules"}
 IGNORE_FILES = {".DS_Store"}
 SOURCE_REPO = "huggingface/skills"
 ARCHIVE_MEDIA_TYPE = "application/gzip"
+AGENT_SKILLS_SCHEMA_URI = "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
 
 
 @dataclass(frozen=True)
@@ -327,6 +332,35 @@ def build_distribution(skills_dir: Path, out_dir: Path, uri_prefix: str) -> None
 	(out_dir / "_SUCCESS").write_text(generated_at + "\n", encoding="utf-8")
 
 
+def build_agent_skills_distribution(skills_dir: Path, out_dir: Path, public_base_url: str) -> None:
+	if out_dir.exists():
+		shutil.rmtree(out_dir)
+	out_dir.mkdir(parents=True)
+
+	entries = []
+	for skill in load_skills(skills_dir):
+		if len(skill.files) == 1 and skill.files[0].name == "SKILL.md":
+			artifact = write_skill_md(skill, out_dir)
+			artifact_type = "skill-md"
+			relative_url = f"{skill.name}/SKILL.md"
+		else:
+			artifact = write_archive(skill, out_dir)
+			artifact_type = "archive"
+			relative_url = f"{skill.name}.tar.gz"
+
+		entries.append(
+			{
+				"name": skill.name,
+				"type": artifact_type,
+				"description": skill.description,
+				"url": uri_join(public_base_url, relative_url),
+				"digest": f"sha256:{sha256_hex(artifact)}",
+			}
+		)
+
+	write_json(out_dir / "index.json", {"$schema": AGENT_SKILLS_SCHEMA_URI, "skills": entries})
+
+
 def write_json(path: Path, value: dict[str, Any]) -> None:
 	path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
@@ -336,12 +370,23 @@ def parse_args() -> argparse.Namespace:
 	parser.add_argument("--skills-dir", type=Path, default=Path("skills"), help="directory containing skill subdirectories")
 	parser.add_argument("--out-dir", type=Path, required=True, help="distribution output directory")
 	parser.add_argument("--uri-prefix", default="skill://", help="URI prefix used in generated indexes")
+	parser.add_argument("--agent-skills-out-dir", type=Path, help="Cloudflare Agent Skills distribution output directory")
+	parser.add_argument("--agent-skills-public-base-url", help="public base URL for Cloudflare Agent Skills artifacts")
 	return parser.parse_args()
 
 
 def main() -> None:
 	args = parse_args()
-	build_distribution(args.skills_dir.resolve(), args.out_dir.resolve(), args.uri_prefix)
+	if bool(args.agent_skills_out_dir) != bool(args.agent_skills_public_base_url):
+		raise ValueError("--agent-skills-out-dir and --agent-skills-public-base-url must be provided together")
+	skills_dir = args.skills_dir.resolve()
+	build_distribution(skills_dir, args.out_dir.resolve(), args.uri_prefix)
+	if args.agent_skills_out_dir:
+		build_agent_skills_distribution(
+			skills_dir,
+			args.agent_skills_out_dir.resolve(),
+			args.agent_skills_public_base_url,
+		)
 
 
 if __name__ == "__main__":

--- a/scripts/test_build_skill_distribution.py
+++ b/scripts/test_build_skill_distribution.py
@@ -11,6 +11,7 @@ import importlib.util
 import json
 import re
 import sys
+import tarfile
 import tempfile
 import unittest
 from pathlib import Path
@@ -113,6 +114,51 @@ class BuildSkillDistributionTest(unittest.TestCase):
 
 			manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
 			self.assertEqual(manifest["artifacts"]["skills_catalog"], "skills.json")
+
+	def test_writes_cloudflare_agent_skills_distribution(self) -> None:
+		with tempfile.TemporaryDirectory() as temp_dir:
+			root = Path(temp_dir)
+			skills_dir = root / "skills"
+			out_dir = root / "out"
+			public_base_url = "https://example.com/agent-skills/latest"
+
+			single = skills_dir / "single"
+			write_skill(single, "Single-file skill")
+
+			multi = skills_dir / "multi"
+			write_skill(multi, "Multi-file skill")
+			(multi / "reference.md").write_text("# Reference\n", encoding="utf-8")
+
+			builder.build_agent_skills_distribution(skills_dir, out_dir, public_base_url)
+
+			payload = json.loads((out_dir / "index.json").read_text(encoding="utf-8"))
+			self.assertEqual(set(payload), {"$schema", "skills"})
+			self.assertEqual(payload["$schema"], builder.AGENT_SKILLS_SCHEMA_URI)
+			entries = {entry["name"]: entry for entry in payload["skills"]}
+			self.assertEqual((out_dir / "single" / "SKILL.md").read_bytes(), (single / "SKILL.md").read_bytes())
+			with tarfile.open(out_dir / "multi.tar.gz", "r:gz") as archive:
+				self.assertEqual(set(archive.getnames()), {"SKILL.md", "reference.md"})
+				self.assertEqual(archive.extractfile("SKILL.md").read(), (multi / "SKILL.md").read_bytes())
+			self.assertEqual(
+				entries["single"],
+				{
+					"name": "single",
+					"type": "skill-md",
+					"description": "Single-file skill",
+					"url": f"{public_base_url}/single/SKILL.md",
+					"digest": "sha256:" + hashlib.sha256((out_dir / "single" / "SKILL.md").read_bytes()).hexdigest(),
+				},
+			)
+			self.assertEqual(
+				entries["multi"],
+				{
+					"name": "multi",
+					"type": "archive",
+					"description": "Multi-file skill",
+					"url": f"{public_base_url}/multi.tar.gz",
+					"digest": "sha256:" + hashlib.sha256((out_dir / "multi.tar.gz").read_bytes()).hexdigest(),
+				},
+			)
 
 	def test_rejects_non_string_metadata_values(self) -> None:
 		with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- generate a separate Agent Skills discovery v0.2 index alongside the existing distribution
- publish single-file skills as direct `SKILL.md` artifacts and multi-file skills as deterministic tar archives
- include public artifact URLs and SHA-256 digests in the discovery index
- sync the generated distribution to `hf://buckets/huggingface/skills/agent-skills/latest`
- cover both direct and archived artifacts with unit tests

## Testing

- `uv run scripts/test_build_skill_distribution.py`
- full distribution build against all repository skills with both legacy and Agent Skills outputs enabled
