### PR TITLE
Fix trl example script links after examples/ reorg

### DIFF
--- a/.claude-plugin/marketplace-internal.json
+++ b/.claude-plugin/marketplace-internal.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Full Hugging Face Skills manifest for hf skills, MCP, and discovery. Client plugin marketplaces use curated manifests.",
-    "version": "1.0.25"
+    "version": "1.0.26"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-    "version": "1.0.25"
+    "version": "1.0.26"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "author": {
     "name": "Hugging Face"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-    "version": "1.0.25"
+    "version": "1.0.26"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "skills": "skills",
   "mcpServers": ".mcp.json",
   "description": "Core Hugging Face Hub operations through the hf CLI, including skill installation, repo management, jobs, datasets, models, Spaces, and discovery.",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "author": {
     "name": "Hugging Face"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "huggingface-skills",
   "description": "Provides access to the Hugging Face Skills.",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "contextFileName": "agentsmd/AGENTS.md",
   "mcpServers": {
     "huggingface-skills": {

--- a/skills/huggingface-llm-trainer/SKILL.md
+++ b/skills/huggingface-llm-trainer/SKILL.md
@@ -266,7 +266,7 @@ hf_jobs("uv", {
 
 **Benefits:** No code to write, maintained by TRL team, production-tested
 **When to use:** Standard TRL training, quick experiments, don't need custom code
-**Available:** Scripts are available from https://github.com/huggingface/trl/tree/main/examples/scripts
+**Available:** Scripts are available from https://github.com/huggingface/trl/tree/main/examples
 
 ### Finding More UV Scripts on Hub
 
@@ -720,7 +720,7 @@ Add to PEP 723 header:
 - [TRL Jobs Training Guide](https://huggingface.co/docs/trl/en/jobs_training)
 - [TRL Jobs Package](https://github.com/huggingface/trl-jobs)
 - [HF Jobs Documentation](https://huggingface.co/docs/huggingface_hub/guides/jobs)
-- [TRL Example Scripts](https://github.com/huggingface/trl/tree/main/examples/scripts)
+- [TRL Example Scripts](https://github.com/huggingface/trl/tree/main/examples)
 - [UV Scripts Guide](https://docs.astral.sh/uv/guides/scripts/)
 - [UV Scripts Organization](https://huggingface.co/uv-scripts)
 

--- a/skills/huggingface-llm-trainer/references/training_methods.md
+++ b/skills/huggingface-llm-trainer/references/training_methods.md
@@ -82,7 +82,7 @@ trainer.train()
 ```python
 # Use TRL maintained script
 hf_jobs("uv", {
-    "script": "https://raw.githubusercontent.com/huggingface/trl/main/examples/scripts/grpo.py",
+    "script": "https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/grpo.py",
     "script_args": [
         "--model_name_or_path", "Qwen/Qwen2.5-0.5B-Instruct",
         "--dataset_name", "trl-lib/math_shepherd",

--- a/skills/huggingface-llm-trainer/references/training_patterns.md
+++ b/skills/huggingface-llm-trainer/references/training_patterns.md
@@ -82,7 +82,7 @@ Group Relative Policy Optimization for online reinforcement learning:
 
 ```python
 hf_jobs("uv", {
-    "script": "https://raw.githubusercontent.com/huggingface/trl/main/examples/scripts/grpo.py",
+    "script": "https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/grpo.py",
     "script_args": [
         "--model_name_or_path", "Qwen/Qwen2.5-0.5B-Instruct",
         "--dataset_name", "trl-lib/math_shepherd",

--- a/skills/huggingface-llm-trainer/scripts/train_grpo_example.py
+++ b/skills/huggingface-llm-trainer/scripts/train_grpo_example.py
@@ -27,7 +27,7 @@ Usage with hf_jobs MCP tool:
 Or submit the script content directly inline without saving to a file.
 
 Note: For most GRPO use cases, the TRL maintained script is recommended:
-    https://raw.githubusercontent.com/huggingface/trl/main/examples/scripts/grpo.py
+    https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/grpo.py
 """
 
 import trackio


### PR DESCRIPTION
Two fixes to trl links in the huggingface-llm-trainer skill:

- huggingface/trl#6820 deletes examples/scripts/, so the two directory links in SKILL.md now point to https://github.com/huggingface/trl/tree/main/examples (each example is a self-contained folder there).
- The `hf_jobs uv` examples in training_methods.md, training_patterns.md and train_grpo_example.py pointed to raw examples/scripts/grpo.py, which is already gone from main. Retargeted to https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/grpo.py, which has the same `# /// script` uv header, so the jobs still run as-is.
